### PR TITLE
1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Cargo.lock
 /tests/temp/dir/*/*
 /tests/temp/lib/*/*
 
+.vscode/
+

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -13,7 +13,7 @@ pub struct CopyOptions {
     pub skip_exist: bool,
     /// Sets buffer size for copy/move work only with receipt information about process work.
     pub buffer_size: usize,
-    /// Sets the option true for recursively copying a directory with a new name or place it inside the destination.
+    /// Sets the option true for recursively copying a directory with a new name or place it inside the destination.(same behaviors like cp -r in Unix)
     pub copy_inside: bool,
 }
 
@@ -26,6 +26,8 @@ impl CopyOptions {
     /// skip_exist: false
     ///
     /// buffer_size: 64000 //64kb
+    ///
+    /// copy_inside: false
     /// ```
     pub fn new() -> CopyOptions {
         CopyOptions {

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -15,6 +15,10 @@ pub struct CopyOptions {
     pub buffer_size: usize,
     /// Sets the option true for recursively copying a directory with a new name or place it inside the destination.(same behaviors like cp -r in Unix)
     pub copy_inside: bool,
+    /// Sets levels reading. Set 0 for read all directory folder. By default 0.
+    ///
+    /// Warrning: Work only for copy operations!
+    pub depth: u64
 }
 
 impl CopyOptions {
@@ -35,6 +39,7 @@ impl CopyOptions {
             skip_exist: false,
             buffer_size: 64000, //64kb
             copy_inside: false,
+            depth: 0,
         }
     }
 }
@@ -562,7 +567,12 @@ where
         }
     }
 
-    let dir_content = get_dir_content(from)?;
+    let mut read_options = DirOptions::new();
+    if options.depth > 0 {
+        read_options.depth = options.depth;
+    }
+
+    let dir_content = get_dir_content2(from, &read_options)?;
     for directory in dir_content.directories {
         let tmp_to = Path::new(&directory).strip_prefix(from)?;
         let dir = to.join(&tmp_to);
@@ -845,7 +855,12 @@ where
         }
     }
 
-    let dir_content = get_dir_content(from)?;
+    let mut read_options = DirOptions::new();
+    if options.depth > 0{
+        read_options.depth = options.depth;
+    }
+
+    let dir_content = get_dir_content2(from, &read_options)?;
     for directory in dir_content.directories {
         let tmp_to = Path::new(&directory).strip_prefix(from)?;
         let dir = to.join(&tmp_to);

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -697,12 +697,12 @@ where
     if path.as_ref().is_dir() {
         directories.push(item);
         if depth == 0 || depth > 1 {
+            if depth > 1 {
+                depth -= 1;
+            }
             for entry in read_dir(&path)? {
                 let _path = entry?.path();
 
-                if depth > 1 {
-                    depth -= 1;
-                }
                 match _get_dir_content(_path, depth) {
                     Ok(items) => {
                         let mut _files = items.files;

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -39,12 +39,19 @@ impl CopyOptions {
     }
 }
 
+///	Options and flags which can be used to configure how read a directory.
 #[derive(Clone)]
 pub struct DirOptions {
+    /// Sets levels reading. Set value 0 for read all directory folder. By default 0. 
     pub depth: u64,
 }
 
 impl DirOptions {
+    /// Initialize struct DirOptions with default value.
+    ///
+    /// ```rust,ignore
+    /// depth: 0
+    /// ```
     pub fn new() -> DirOptions {
         DirOptions {
             depth: 0 //  0 - all; 1 - only first level; 2 - second level; ... etc.   
@@ -634,6 +641,35 @@ where
     get_dir_content2(path, &options)
 }
 
+
+/// Return DirContent which containt information about directory:
+///
+/// * Size directory.
+/// * List all files source directory(files subdirectories  included too).
+/// * List all directory and subdirectories source path.
+///
+/// # Errors
+///
+/// This function will return an error in the following situations, but is not limited to just
+/// these cases:
+///
+/// * This `path` directory does not exist.
+/// * Invalid `path`.
+/// * The current process does not have the permission rights to access `path`.
+///
+/// # Examples
+/// ```rust,ignore
+/// extern crate fs_extra;
+/// use fs_extra::dir::get_dir_content2;
+///
+/// let options = DirOptions::new();
+/// options.depth = 3; // Get 3 levels of folder.
+/// let dir_content = get_dir_content2("dir", &options)?;
+/// for directory in dir_content.directories {
+///     println!("{}", directory); // print directory path
+/// }
+/// ```
+///
 pub fn get_dir_content2<P>(path: P, options: &DirOptions) -> Result<DirContent>
 where
     P: AsRef<Path>,

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -194,35 +194,43 @@ pub struct LsResult {
 /// let entry_info = get_details_entry("test", &config);
 /// assert_eq!(2, entry_info.len());
 /// ```
-pub fn get_details_entry<P>(path: P,
-                            config: &HashSet<DirEntryAttr>)
-                            -> Result<HashMap<DirEntryAttr, DirEntryValue>>
-    where P: AsRef<Path>
+pub fn get_details_entry<P>(
+    path: P,
+    config: &HashSet<DirEntryAttr>,
+) -> Result<HashMap<DirEntryAttr, DirEntryValue>>
+where
+    P: AsRef<Path>,
 {
     let path = path.as_ref();
     let metadata = path.metadata()?;
     get_details_entry_with_meta(path, config, metadata)
 }
-fn get_details_entry_with_meta<P>(path: P,
-                                  config: &HashSet<DirEntryAttr>,
-                                  metadata: Metadata)
-                                  -> Result<HashMap<DirEntryAttr, DirEntryValue>>
-    where P: AsRef<Path>
+fn get_details_entry_with_meta<P>(
+    path: P,
+    config: &HashSet<DirEntryAttr>,
+    metadata: Metadata,
+) -> Result<HashMap<DirEntryAttr, DirEntryValue>>
+where
+    P: AsRef<Path>,
 {
     let path = path.as_ref();
     let mut item = HashMap::new();
     if config.contains(&DirEntryAttr::Name) {
         if metadata.is_dir() {
             if let Some(file_name) = path.file_name() {
-                item.insert(DirEntryAttr::Name,
-                            DirEntryValue::String(file_name.to_os_string().into_string()?));
+                item.insert(
+                    DirEntryAttr::Name,
+                    DirEntryValue::String(file_name.to_os_string().into_string()?),
+                );
             } else {
                 item.insert(DirEntryAttr::Name, DirEntryValue::String(String::new()));
             }
         } else {
             if let Some(file_stem) = path.file_stem() {
-                item.insert(DirEntryAttr::Name,
-                            DirEntryValue::String(file_stem.to_os_string().into_string()?));
+                item.insert(
+                    DirEntryAttr::Name,
+                    DirEntryValue::String(file_stem.to_os_string().into_string()?),
+                );
             } else {
                 item.insert(DirEntryAttr::Name, DirEntryValue::String(String::new()));
             }
@@ -230,16 +238,20 @@ fn get_details_entry_with_meta<P>(path: P,
     }
     if config.contains(&DirEntryAttr::Ext) {
         if let Some(value) = path.extension() {
-            item.insert(DirEntryAttr::Ext,
-                        DirEntryValue::String(value.to_os_string().into_string()?));
+            item.insert(
+                DirEntryAttr::Ext,
+                DirEntryValue::String(value.to_os_string().into_string()?),
+            );
         } else {
             item.insert(DirEntryAttr::Ext, DirEntryValue::String(String::from("")));
         }
     }
     if config.contains(&DirEntryAttr::FullName) {
         if let Some(file_name) = path.file_name() {
-            item.insert(DirEntryAttr::FullName,
-                        DirEntryValue::String(file_name.to_os_string().into_string()?));
+            item.insert(
+                DirEntryAttr::FullName,
+                DirEntryValue::String(file_name.to_os_string().into_string()?),
+            );
         } else {
             item.insert(DirEntryAttr::FullName, DirEntryValue::String(String::new()));
         }
@@ -300,24 +312,34 @@ fn get_details_entry_with_meta<P>(path: P,
         item.insert(DirEntryAttr::FileSize, DirEntryValue::U64(metadata.len()));
     }
     if config.contains(&DirEntryAttr::IsDir) {
-        item.insert(DirEntryAttr::IsDir,
-                    DirEntryValue::Boolean(metadata.is_dir()));
+        item.insert(
+            DirEntryAttr::IsDir,
+            DirEntryValue::Boolean(metadata.is_dir()),
+        );
     }
     if config.contains(&DirEntryAttr::IsFile) {
-        item.insert(DirEntryAttr::IsFile,
-                    DirEntryValue::Boolean(metadata.is_file()));
+        item.insert(
+            DirEntryAttr::IsFile,
+            DirEntryValue::Boolean(metadata.is_file()),
+        );
     }
     if config.contains(&DirEntryAttr::Modified) {
-        item.insert(DirEntryAttr::Modified,
-                    DirEntryValue::SystemTime(metadata.modified()?));
+        item.insert(
+            DirEntryAttr::Modified,
+            DirEntryValue::SystemTime(metadata.modified()?),
+        );
     }
     if config.contains(&DirEntryAttr::Accessed) {
-        item.insert(DirEntryAttr::Accessed,
-                    DirEntryValue::SystemTime(metadata.accessed()?));
+        item.insert(
+            DirEntryAttr::Accessed,
+            DirEntryValue::SystemTime(metadata.accessed()?),
+        );
     }
     if config.contains(&DirEntryAttr::Created) {
-        item.insert(DirEntryAttr::Created,
-                    DirEntryValue::SystemTime(metadata.created()?));
+        item.insert(
+            DirEntryAttr::Created,
+            DirEntryValue::SystemTime(metadata.created()?),
+        );
     }
     Ok(item)
 
@@ -357,7 +379,8 @@ fn get_details_entry_with_meta<P>(path: P,
 /// assert_eq!(2, ls_result.base.len());
 /// ```
 pub fn ls<P>(path: P, config: &HashSet<DirEntryAttr>) -> Result<LsResult>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     let mut items = Vec::new();
     let path = path.as_ref();
@@ -407,7 +430,8 @@ pub fn ls<P>(path: P, config: &HashSet<DirEntryAttr>) -> Result<LsResult>
 /// create("dir", false); // create directory
 /// ```
 pub fn create<P>(path: P, erase: bool) -> Result<()>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     if erase && path.as_ref().exists() {
         remove(&path)?;
@@ -440,7 +464,8 @@ pub fn create<P>(path: P, erase: bool) -> Result<()>
 ///
 /// create_all("/some/dir", false); // create directory some and dir
 pub fn create_all<P>(path: P, erase: bool) -> Result<()>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     if erase && path.as_ref().exists() {
         remove(&path)?;
@@ -476,8 +501,9 @@ pub fn create_all<P>(path: P, erase: bool) -> Result<()>
 ///
 /// ```
 pub fn copy<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
 {
     let from = from.as_ref();
 
@@ -486,8 +512,10 @@ pub fn copy<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
             let msg = format!("Path \"{}\" does not exist or you don't have access!", msg);
             err!(&msg, ErrorKind::NotFound);
         }
-        err!("Path does not exist Or you don't have access!",
-             ErrorKind::NotFound);
+        err!(
+            "Path does not exist Or you don't have access!",
+            ErrorKind::NotFound
+        );
     }
     if !from.is_dir() {
         if let Some(msg) = from.to_str() {
@@ -585,7 +613,8 @@ pub fn copy<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
 /// ```
 ///
 pub fn get_dir_content<P>(path: P) -> Result<DirContent>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     let mut directories = Vec::new();
     let mut files = Vec::new();
@@ -644,7 +673,8 @@ pub fn get_dir_content<P>(path: P) -> Result<DirContent>
 /// println!("{}", folder_size); // print directory sile in bytes
 /// ```
 pub fn get_size<P>(path: P) -> Result<u64>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     let mut result = 0;
 
@@ -692,14 +722,16 @@ pub fn get_size<P>(path: P) -> Result<u64>
 /// copy_with_progress("source/dir1", "target/dir1", &options, handle)?;
 ///
 /// ```
-pub fn copy_with_progress<P, Q, F>(from: P,
-                                   to: Q,
-                                   options: &CopyOptions,
-                                   mut progress_handler: F)
-                                   -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>,
-          F: FnMut(TransitProcess) -> TransitProcessResult
+pub fn copy_with_progress<P, Q, F>(
+    from: P,
+    to: Q,
+    options: &CopyOptions,
+    mut progress_handler: F,
+) -> Result<u64>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+    F: FnMut(TransitProcess) -> TransitProcessResult,
 {
     let from = from.as_ref();
 
@@ -708,8 +740,10 @@ pub fn copy_with_progress<P, Q, F>(from: P,
             let msg = format!("Path \"{}\" does not exist or you don't have access!", msg);
             err!(&msg, ErrorKind::NotFound);
         }
-        err!("Path does not exist or you don't have access!",
-             ErrorKind::NotFound);
+        err!(
+            "Path does not exist or you don't have access!",
+            ErrorKind::NotFound
+        );
     }
 
     let mut to: PathBuf = to.as_ref().to_path_buf();
@@ -911,8 +945,9 @@ pub fn copy_with_progress<P, Q, F>(from: P,
 ///
 /// ```
 pub fn move_dir<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
 {
     let mut is_remove = true;
     if options.skip_exist && to.as_ref().exists() && !options.overwrite {
@@ -925,19 +960,25 @@ pub fn move_dir<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
             let msg = format!("Path \"{}\" does not exist", msg);
             err!(&msg, ErrorKind::NotFound);
         }
-        err!("Path does not exist or you don't have access!",
-             ErrorKind::NotFound);
+        err!(
+            "Path does not exist or you don't have access!",
+            ErrorKind::NotFound
+        );
     }
 
     let mut to: PathBuf = to.as_ref().to_path_buf();
     if !from.is_dir() {
         if let Some(msg) = from.to_str() {
-          let msg = format!("Path \"{}\" is not a directory or you don't have access!",
-                              msg); 
+            let msg = format!(
+                "Path \"{}\" is not a directory or you don't have access!",
+                msg
+            );
             err!(&msg, ErrorKind::InvalidFolder);
         }
-        err!("Path is not a directory or you don't have access!",
-             ErrorKind::InvalidFolder); 
+        err!(
+            "Path is not a directory or you don't have access!",
+            ErrorKind::InvalidFolder
+        );
     }
 
     if options.copy_inside {
@@ -1035,14 +1076,16 @@ pub fn move_dir<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
 /// move_dir_with_progress("source/dir1", "target/dir1", &options, handle)?;
 ///
 /// ```
-pub fn move_dir_with_progress<P, Q, F>(from: P,
-                                       to: Q,
-                                       options: &CopyOptions,
-                                       mut progress_handler: F)
-                                       -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>,
-          F: FnMut(TransitProcess) -> TransitProcessResult
+pub fn move_dir_with_progress<P, Q, F>(
+    from: P,
+    to: Q,
+    options: &CopyOptions,
+    mut progress_handler: F,
+) -> Result<u64>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+    F: FnMut(TransitProcess) -> TransitProcessResult,
 {
     let mut is_remove = true;
     if options.skip_exist && to.as_ref().exists() && !options.overwrite {
@@ -1055,8 +1098,10 @@ pub fn move_dir_with_progress<P, Q, F>(from: P,
             let msg = format!("Path \"{}\" does not exist or you don't have access!", msg);
             err!(&msg, ErrorKind::NotFound);
         }
-        err!("Path does not exist or you don't have access!",
-             ErrorKind::NotFound);
+        err!(
+            "Path does not exist or you don't have access!",
+            ErrorKind::NotFound
+        );
     }
 
     let mut to: PathBuf = to.as_ref().to_path_buf();
@@ -1146,10 +1191,12 @@ pub fn move_dir_with_progress<P, Q, F>(from: P,
                     progress_handler(info_process.clone());
                 };
 
-                result_copy = super::file::move_file_with_progress(&file,
-                                                                   &path,
-                                                                   &file_options,
-                                                                   _progress_handler);
+                result_copy = super::file::move_file_with_progress(
+                    &file,
+                    &path,
+                    &file_options,
+                    _progress_handler,
+                );
             }
             match result_copy {
                 Ok(val) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,15 +125,19 @@ impl StdError for Error {
 }
 impl From<StripPrefixError> for Error {
     fn from(err: StripPrefixError) -> Error {
-        Error::new(ErrorKind::StripPrefix(err),
-                   "StripPrefixError. Look inside for more details")
+        Error::new(
+            ErrorKind::StripPrefix(err),
+            "StripPrefixError. Look inside for more details",
+        )
     }
 }
 
 impl From<OsString> for Error {
     fn from(err: OsString) -> Error {
-        Error::new(ErrorKind::OsString(err),
-                   "OsString. Look inside for more details")
+        Error::new(
+            ErrorKind::OsString(err),
+            "OsString. Look inside for more details",
+        )
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -64,8 +64,9 @@ pub struct TransitProcess {
 ///
 /// ```
 pub fn copy<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
 {
 
     let from = from.as_ref();
@@ -74,8 +75,10 @@ pub fn copy<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
             let msg = format!("Path \"{}\" does not exist or you don't have access!", msg);
             err!(&msg, ErrorKind::NotFound);
         }
-        err!("Path does not exist or you don't have access!",
-             ErrorKind::NotFound);
+        err!(
+            "Path does not exist or you don't have access!",
+            ErrorKind::NotFound
+        );
     }
 
     if !from.is_file() {
@@ -127,14 +130,16 @@ pub fn copy<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
 /// copy_with_progress("dir1/foo.txt", "dir2/foo.txt", &options, handle)?;
 ///
 /// ```
-pub fn copy_with_progress<P, Q, F>(from: P,
-                                   to: Q,
-                                   options: &CopyOptions,
-                                   mut progress_handler: F)
-                                   -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>,
-          F: FnMut(TransitProcess) -> ()
+pub fn copy_with_progress<P, Q, F>(
+    from: P,
+    to: Q,
+    options: &CopyOptions,
+    mut progress_handler: F,
+) -> Result<u64>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+    F: FnMut(TransitProcess) -> (),
 {
     let from = from.as_ref();
     if !from.exists() {
@@ -142,8 +147,10 @@ pub fn copy_with_progress<P, Q, F>(from: P,
             let msg = format!("Path \"{}\" does not exist or you don't have access!", msg);
             err!(&msg, ErrorKind::NotFound);
         }
-        err!("Path does not exist or you don't have access!",
-             ErrorKind::NotFound);
+        err!(
+            "Path does not exist or you don't have access!",
+            ErrorKind::NotFound
+        );
     }
 
     if !from.is_file() {
@@ -214,8 +221,9 @@ pub fn copy_with_progress<P, Q, F>(from: P,
 ///
 /// ```
 pub fn move_file<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
 {
     let mut is_remove = true;
     if options.skip_exist && to.as_ref().exists() && !options.overwrite {
@@ -254,14 +262,16 @@ pub fn move_file<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
 /// move_file("dir1/foo.txt", "dir2/foo.txt", &options, handle)?;
 ///
 /// ```
-pub fn move_file_with_progress<P, Q, F>(from: P,
-                                        to: Q,
-                                        options: &CopyOptions,
-                                        progress_handler: F)
-                                        -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>,
-          F: FnMut(TransitProcess) -> ()
+pub fn move_file_with_progress<P, Q, F>(
+    from: P,
+    to: Q,
+    options: &CopyOptions,
+    progress_handler: F,
+) -> Result<u64>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+    F: FnMut(TransitProcess) -> (),
 {
     let mut is_remove = true;
     if options.skip_exist && to.as_ref().exists() && !options.overwrite {
@@ -294,7 +304,8 @@ pub fn move_file_with_progress<P, Q, F>(from: P,
 ///
 /// ```
 pub fn remove<P>(path: P) -> Result<()>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     if path.as_ref().exists() {
         Ok(remove_file(path)?)
@@ -324,7 +335,8 @@ pub fn remove<P>(path: P) -> Result<()>
 ///
 /// ```
 pub fn read_to_string<P>(path: P) -> Result<String>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     let path = path.as_ref();
     if path.exists() && !path.is_file() {
@@ -362,7 +374,8 @@ pub fn read_to_string<P>(path: P) -> Result<String>
 ///
 /// ```
 pub fn write_all<P>(path: P, content: &str) -> Result<()>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     let path = path.as_ref();
     if path.exists() && !path.is_file() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,8 +188,9 @@ use std::path::Path;
 /// ```
 ///
 pub fn copy_items<P, Q>(from: &Vec<P>, to: Q, options: &dir::CopyOptions) -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
 {
     let mut result: u64 = 0;
     for item in from {
@@ -281,14 +282,16 @@ impl Clone for TransitProcess {
 ///  copy_items_with_progress(&from_paths, "target", &options, handle)?;
 /// ```
 ///
-pub fn copy_items_with_progress<P, Q, F>(from: &Vec<P>,
-                                         to: Q,
-                                         options: &dir::CopyOptions,
-                                         mut progress_handler: F)
-                                         -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>,
-          F: FnMut(TransitProcess) -> dir::TransitProcessResult
+pub fn copy_items_with_progress<P, Q, F>(
+    from: &Vec<P>,
+    to: Q,
+    options: &dir::CopyOptions,
+    mut progress_handler: F,
+) -> Result<u64>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+    F: FnMut(TransitProcess) -> dir::TransitProcessResult,
 {
 
     let mut total_size = 0;
@@ -415,12 +418,16 @@ pub fn copy_items_with_progress<P, Q, F>(from: &Vec<P>,
                                 let user_decide = progress_handler(info_process);
                                 match user_decide {
                                     dir::TransitProcessResult::Overwrite => {
-                                        err!("Overwrite denied for this situation!",
-                                             ErrorKind::Other);
+                                        err!(
+                                            "Overwrite denied for this situation!",
+                                            ErrorKind::Other
+                                        );
                                     }
                                     dir::TransitProcessResult::OverwriteAll => {
-                                        err!("Overwrite denied for this situation!",
-                                             ErrorKind::Other);
+                                        err!(
+                                            "Overwrite denied for this situation!",
+                                            ErrorKind::Other
+                                        );
                                     }
                                     dir::TransitProcessResult::Skip => {
                                         file_options.skip_exist = true;
@@ -487,8 +494,9 @@ pub fn copy_items_with_progress<P, Q, F>(from: &Vec<P>,
 /// ```
 ///
 pub fn move_items<P, Q>(from_items: &Vec<P>, to: Q, options: &dir::CopyOptions) -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
 {
     let mut total_size = 0;
     let mut list_paths = Vec::new();
@@ -586,14 +594,16 @@ pub fn move_items<P, Q>(from_items: &Vec<P>, to: Q, options: &dir::CopyOptions) 
 ///  move_items_with_progress(&from_paths, "target", &options, handle)?;
 /// ```
 ///
-pub fn move_items_with_progress<P, Q, F>(from_items: &Vec<P>,
-                                         to: Q,
-                                         options: &dir::CopyOptions,
-                                         mut progress_handler: F)
-                                         -> Result<u64>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>,
-          F: FnMut(TransitProcess) -> dir::TransitProcessResult
+pub fn move_items_with_progress<P, Q, F>(
+    from_items: &Vec<P>,
+    to: Q,
+    options: &dir::CopyOptions,
+    mut progress_handler: F,
+) -> Result<u64>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
+    F: FnMut(TransitProcess) -> dir::TransitProcessResult,
 {
     let mut total_size = 0;
     let mut list_paths = Vec::new();
@@ -720,12 +730,16 @@ pub fn move_items_with_progress<P, Q, F>(from_items: &Vec<P>,
                                 let user_decide = progress_handler(info_process);
                                 match user_decide {
                                     dir::TransitProcessResult::Overwrite => {
-                                        err!("Overwrite denied for this situation!",
-                                             ErrorKind::Other);
+                                        err!(
+                                            "Overwrite denied for this situation!",
+                                            ErrorKind::Other
+                                        );
                                     }
                                     dir::TransitProcessResult::OverwriteAll => {
-                                        err!("Overwrite denied for this situation!",
-                                             ErrorKind::Other);
+                                        err!(
+                                            "Overwrite denied for this situation!",
+                                            ErrorKind::Other
+                                        );
                                     }
                                     dir::TransitProcessResult::Skip => {
                                         file_options.skip_exist = true;
@@ -774,7 +788,8 @@ pub fn move_items_with_progress<P, Q, F>(from_items: &Vec<P>,
 /// ```
 ///
 pub fn remove_items<P>(from_items: &Vec<P>) -> Result<()>
-    where P: AsRef<Path>
+where
+    P: AsRef<Path>,
 {
     for item in from_items {
         let item = item.as_ref();

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -645,7 +645,7 @@ fn it_copy_using_first_levels(){
 
 
 #[test]
-fn it_copy_using_four_levels() {
+fn it_copy_using_four_levels(){
 
     let test_dir = Path::new(TEST_FOLDER).join("it_copy_using_four_levels");
     let path_to = test_dir.join("out");
@@ -1251,6 +1251,229 @@ fn it_copy_with_progress_exist_overwrite_and_skip_exist() {
     }
     rx.recv().unwrap();
 
+}
+
+#[test]
+fn it_copy_with_progress_using_first_levels(){
+
+    let test_dir = Path::new(TEST_FOLDER).join("it_copy_with_progress_using_first_levels");
+    let path_to = test_dir.join("out");
+    let d_level_1 = (test_dir.join("d_level_1"), path_to.join("d_level_1"));
+    let d_level_2 = (d_level_1.0.join("d_level_2"), d_level_1.1.join("d_level_2"));
+    let d_level_3 = (d_level_2.0.join("d_level_3"), d_level_2.1.join("d_level_3"));
+    let d_level_4 = (d_level_3.0.join("d_level_4"), d_level_3.1.join("d_level_4"));
+    let d_level_5 = (d_level_4.0.join("d_level_5"), d_level_4.1.join("d_level_5"));
+
+    let file1 = (d_level_1.0.join("file1.txt"),d_level_1.1.join("file1.txt"));
+    let file2 = (d_level_2.0.join("file2.txt"),d_level_2.1.join("file2.txt"));
+    let file3 = (d_level_3.0.join("file3.txt"),d_level_3.1.join("file3.txt"));
+    let file4 = (d_level_4.0.join("file4.txt"),d_level_4.1.join("file4.txt"));
+    let file5 = (d_level_5.0.join("file5.txt"),d_level_5.1.join("file5.txt"));
+
+    create_all(&d_level_1.0, true).unwrap();
+    create_all(&d_level_2.0, true).unwrap();
+    create_all(&d_level_3.0, true).unwrap();
+    create_all(&d_level_4.0, true).unwrap();
+    create_all(&d_level_5.0, true).unwrap();
+    create_all(&path_to, true).unwrap();
+
+    assert!(path_to.exists());
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+
+    assert!(!d_level_1.1.exists());
+    assert!(!d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    fs_extra::file::write_all(&file1.0, "content1").unwrap();
+    fs_extra::file::write_all(&file2.0, "content2").unwrap();
+    fs_extra::file::write_all(&file3.0, "content3").unwrap();
+    fs_extra::file::write_all(&file4.0, "content4").unwrap();
+    fs_extra::file::write_all(&file5.0, "content5").unwrap();
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(!file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    let mut options = CopyOptions::new();
+    options.depth = 1;
+    let (tx, rx) = mpsc::channel();
+    let result = thread::spawn(move || {
+        let func_test = |process_info: TransitProcess| {
+            tx.send(process_info).unwrap();
+            TransitProcessResult::ContinueOrAbort
+        };
+
+        let result = copy_with_progress(&d_level_1.0, &path_to, &options, func_test).unwrap();
+
+        assert_eq!(8, result);
+
+        assert!(d_level_1.0.exists());
+        assert!(d_level_2.0.exists());
+        assert!(d_level_3.0.exists());
+        assert!(d_level_4.0.exists());
+        assert!(d_level_5.0.exists());
+
+        assert!(d_level_1.1.exists());
+        assert!(d_level_2.1.exists());
+        assert!(!d_level_3.1.exists());
+        assert!(!d_level_4.1.exists());
+        assert!(!d_level_5.1.exists());
+
+        assert!(file1.0.exists());
+        assert!(file2.0.exists());
+        assert!(file3.0.exists());
+        assert!(file4.0.exists());
+        assert!(file5.0.exists());
+
+        assert!(file1.1.exists());
+        assert!(!file2.1.exists());
+        assert!(!file3.1.exists());
+        assert!(!file4.1.exists());
+        assert!(!file5.1.exists());
+        assert!(files_eq(&file1.0, &file1.1));
+
+    }).join();
+
+
+    match result {
+        Ok(_) => {}
+        Err(err) => panic!(err),
+    }
+
+    match rx.recv() {
+        Err(_) => panic!("Errors should not be!"),
+        _ => {}
+
+    }
+
+}
+
+
+#[test]
+fn it_copy_with_progress_using_four_levels() {
+
+    let test_dir = Path::new(TEST_FOLDER).join("it_copy_with_progress_using_four_levels");
+    let path_to = test_dir.join("out");
+    let d_level_1 = (test_dir.join("d_level_1"), path_to.join("d_level_1"));
+    let d_level_2 = (d_level_1.0.join("d_level_2"), d_level_1.1.join("d_level_2"));
+    let d_level_3 = (d_level_2.0.join("d_level_3"), d_level_2.1.join("d_level_3"));
+    let d_level_4 = (d_level_3.0.join("d_level_4"), d_level_3.1.join("d_level_4"));
+    let d_level_5 = (d_level_4.0.join("d_level_5"), d_level_4.1.join("d_level_5"));
+
+    let file1 = (d_level_1.0.join("file1.txt"),d_level_1.1.join("file1.txt"));
+    let file2 = (d_level_2.0.join("file2.txt"),d_level_2.1.join("file2.txt"));
+    let file3 = (d_level_3.0.join("file3.txt"),d_level_3.1.join("file3.txt"));
+    let file4 = (d_level_4.0.join("file4.txt"),d_level_4.1.join("file4.txt"));
+    let file5 = (d_level_5.0.join("file5.txt"),d_level_5.1.join("file5.txt"));
+
+    create_all(&d_level_1.0, true).unwrap();
+    create_all(&d_level_2.0, true).unwrap();
+    create_all(&d_level_3.0, true).unwrap();
+    create_all(&d_level_4.0, true).unwrap();
+    create_all(&d_level_5.0, true).unwrap();
+    create_all(&path_to, true).unwrap();
+
+    assert!(path_to.exists());
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+
+    assert!(!d_level_1.1.exists());
+    assert!(!d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    fs_extra::file::write_all(&file1.0, "content1").unwrap();
+    fs_extra::file::write_all(&file2.0, "content2").unwrap();
+    fs_extra::file::write_all(&file3.0, "content3").unwrap();
+    fs_extra::file::write_all(&file4.0, "content4").unwrap();
+    fs_extra::file::write_all(&file5.0, "content5").unwrap();
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(!file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    let mut options = CopyOptions::new();
+    options.depth = 4;
+    let (tx, rx) = mpsc::channel();
+    let result = thread::spawn(move || {
+        let func_test = |process_info: TransitProcess| {
+            tx.send(process_info).unwrap();
+            TransitProcessResult::ContinueOrAbort
+        };
+
+        let result = copy_with_progress(&d_level_1.0, &path_to, &options, func_test).unwrap();
+
+        assert_eq!(32, result);
+
+        assert!(d_level_1.0.exists());
+        assert!(d_level_2.0.exists());
+        assert!(d_level_3.0.exists());
+        assert!(d_level_4.0.exists());
+        assert!(d_level_5.0.exists());
+
+        assert!(d_level_1.1.exists());
+        assert!(d_level_2.1.exists());
+        assert!(d_level_3.1.exists());
+        assert!(d_level_4.1.exists());
+        assert!(d_level_5.1.exists());
+
+        assert!(file1.0.exists());
+        assert!(file2.0.exists());
+        assert!(file3.0.exists());
+        assert!(file4.0.exists());
+        assert!(file5.0.exists());
+
+        assert!(file1.1.exists());
+        assert!(file2.1.exists());
+        assert!(file3.1.exists());
+        assert!(file4.1.exists());
+        assert!(!file5.1.exists());
+        assert!(files_eq(&file1.0, &file1.1));
+        assert!(files_eq(&file2.0, &file2.1));
+        assert!(files_eq(&file3.0, &file3.1));
+        assert!(files_eq(&file4.0, &file4.1));
+
+    }).join();
+
+
+    match result {
+        Ok(_) => {}
+        Err(err) => panic!(err),
+    }
+
+    match rx.recv() {
+        Err(_) => panic!("Errors should not be!"),
+        _ => {}
+
+    }
 }
 
 #[test]

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -555,7 +555,186 @@ fn it_copy_exist_overwrite_and_skip_exist() {
     assert!(compare_dir(&path_from, &path_to));
 }
 
+#[test]
+fn it_copy_using_first_levels(){
 
+    let test_dir = Path::new(TEST_FOLDER).join("it_copy_using_first_levels");
+    let path_to = test_dir.join("out");
+    let d_level_1 = (test_dir.join("d_level_1"), path_to.join("d_level_1"));
+    let d_level_2 = (d_level_1.0.join("d_level_2"), d_level_1.1.join("d_level_2"));
+    let d_level_3 = (d_level_2.0.join("d_level_3"), d_level_2.1.join("d_level_3"));
+    let d_level_4 = (d_level_3.0.join("d_level_4"), d_level_3.1.join("d_level_4"));
+    let d_level_5 = (d_level_4.0.join("d_level_5"), d_level_4.1.join("d_level_5"));
+
+    let file1 = (d_level_1.0.join("file1.txt"),d_level_1.1.join("file1.txt"));
+    let file2 = (d_level_2.0.join("file2.txt"),d_level_2.1.join("file2.txt"));
+    let file3 = (d_level_3.0.join("file3.txt"),d_level_3.1.join("file3.txt"));
+    let file4 = (d_level_4.0.join("file4.txt"),d_level_4.1.join("file4.txt"));
+    let file5 = (d_level_5.0.join("file5.txt"),d_level_5.1.join("file5.txt"));
+
+    create_all(&d_level_1.0, true).unwrap();
+    create_all(&d_level_2.0, true).unwrap();
+    create_all(&d_level_3.0, true).unwrap();
+    create_all(&d_level_4.0, true).unwrap();
+    create_all(&d_level_5.0, true).unwrap();
+    create_all(&path_to, true).unwrap();
+
+    assert!(path_to.exists());
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+
+    assert!(!d_level_1.1.exists());
+    assert!(!d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    fs_extra::file::write_all(&file1.0, "content1").unwrap();
+    fs_extra::file::write_all(&file2.0, "content2").unwrap();
+    fs_extra::file::write_all(&file3.0, "content3").unwrap();
+    fs_extra::file::write_all(&file4.0, "content4").unwrap();
+    fs_extra::file::write_all(&file5.0, "content5").unwrap();
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(!file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    let mut options = CopyOptions::new();
+    options.depth = 1;
+    let result = copy(&d_level_1.0, path_to, &options).unwrap();
+
+    assert_eq!(8, result);
+
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+    assert!(d_level_1.1.exists());
+    assert!(d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+    assert!(files_eq(&file1.0, &file1.1));
+}
+
+
+#[test]
+fn it_copy_using_four_levels() {
+
+    let test_dir = Path::new(TEST_FOLDER).join("it_copy_using_four_levels");
+    let path_to = test_dir.join("out");
+    let d_level_1 = (test_dir.join("d_level_1"), path_to.join("d_level_1"));
+    let d_level_2 = (d_level_1.0.join("d_level_2"), d_level_1.1.join("d_level_2"));
+    let d_level_3 = (d_level_2.0.join("d_level_3"), d_level_2.1.join("d_level_3"));
+    let d_level_4 = (d_level_3.0.join("d_level_4"), d_level_3.1.join("d_level_4"));
+    let d_level_5 = (d_level_4.0.join("d_level_5"), d_level_4.1.join("d_level_5"));
+
+    let file1 = (d_level_1.0.join("file1.txt"),d_level_1.1.join("file1.txt"));
+    let file2 = (d_level_2.0.join("file2.txt"),d_level_2.1.join("file2.txt"));
+    let file3 = (d_level_3.0.join("file3.txt"),d_level_3.1.join("file3.txt"));
+    let file4 = (d_level_4.0.join("file4.txt"),d_level_4.1.join("file4.txt"));
+    let file5 = (d_level_5.0.join("file5.txt"),d_level_5.1.join("file5.txt"));
+
+    create_all(&d_level_1.0, true).unwrap();
+    create_all(&d_level_2.0, true).unwrap();
+    create_all(&d_level_3.0, true).unwrap();
+    create_all(&d_level_4.0, true).unwrap();
+    create_all(&d_level_5.0, true).unwrap();
+    create_all(&path_to, true).unwrap();
+
+    assert!(path_to.exists());
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+
+    assert!(!d_level_1.1.exists());
+    assert!(!d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    fs_extra::file::write_all(&file1.0, "content1").unwrap();
+    fs_extra::file::write_all(&file2.0, "content2").unwrap();
+    fs_extra::file::write_all(&file3.0, "content3").unwrap();
+    fs_extra::file::write_all(&file4.0, "content4").unwrap();
+    fs_extra::file::write_all(&file5.0, "content5").unwrap();
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(!file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    let mut options = CopyOptions::new();
+    options.depth = 4;
+    let result = copy(&d_level_1.0, path_to, &options).unwrap();
+
+    assert_eq!(32, result);
+
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+    assert!(d_level_1.1.exists());
+    assert!(d_level_2.1.exists());
+    assert!(d_level_3.1.exists());
+    assert!(d_level_4.1.exists());
+    assert!(d_level_5.1.exists());
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(file1.1.exists());
+    assert!(file2.1.exists());
+    assert!(file3.1.exists());
+    assert!(file4.1.exists());
+    assert!(!file5.1.exists());
+
+    assert!(files_eq(&file1.0, &file1.1));
+    assert!(files_eq(&file2.0, &file2.1));
+    assert!(files_eq(&file3.0, &file3.1));
+    assert!(files_eq(&file4.0, &file4.1));
+}
 
 
 #[test]

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -2409,6 +2409,151 @@ fn it_get_dir_content() {
     assert!(directories_correct);
 }
 
+#[test]
+fn it_get_dir_content_many_levels() {
+    let test_dir = Path::new(TEST_FOLDER).join("it_get_dir_content_many_levels");
+    let d_level_1 = test_dir.join("d_level_1");
+    let d_level_2 = d_level_1.join("d_level_2");
+    let d_level_3 = d_level_2.join("d_level_3");
+    let d_level_4 = d_level_3.join("d_level_4");
+    let d_level_5 = d_level_4.join("d_level_5");
+
+    let file1 = d_level_1.join("file1.txt");
+    let file2 = d_level_2.join("file2.txt");
+    let file3 = d_level_3.join("file3.txt");
+    let file4 = d_level_4.join("file4.txt");
+    let file5 = d_level_5.join("file5.txt");
+
+    create_all(&d_level_1, true).unwrap();
+    create_all(&d_level_2, true).unwrap();
+    create_all(&d_level_3, true).unwrap();
+    create_all(&d_level_4, true).unwrap();
+    create_all(&d_level_5, true).unwrap();
+
+    assert!(&d_level_1.exists());
+    assert!(&d_level_2.exists());
+    assert!(&d_level_3.exists());
+    assert!(&d_level_4.exists());
+    assert!(&d_level_5.exists());
+
+    fs_extra::file::write_all(&file1, "content1").unwrap();
+    fs_extra::file::write_all(&file2, "content2").unwrap();
+    fs_extra::file::write_all(&file3, "content3").unwrap();
+    fs_extra::file::write_all(&file4, "content4").unwrap();
+    fs_extra::file::write_all(&file5, "content5").unwrap();
+
+    let mut options = DirOptions::new();
+    let result = get_dir_content2(&d_level_1, &options).unwrap();
+
+    assert_eq!(40, result.dir_size);
+    assert_eq!(5, result.files.len());
+    assert_eq!(5, result.directories.len());
+
+    let mut directories = Vec::new();
+    directories.push(file1.parent().unwrap().to_str().unwrap().to_string());
+    directories.push(file2.parent().unwrap().to_str().unwrap().to_string());
+    directories.push(file3.parent().unwrap().to_str().unwrap().to_string());
+    directories.push(file4.parent().unwrap().to_str().unwrap().to_string());
+    directories.push(file5.parent().unwrap().to_str().unwrap().to_string());
+
+    let mut files = Vec::new();
+    files.push(file1.to_str().unwrap().to_string());
+    files.push(file2.to_str().unwrap().to_string());
+    files.push(file3.to_str().unwrap().to_string());
+    files.push(file4.to_str().unwrap().to_string());
+    files.push(file5.to_str().unwrap().to_string());
+
+    let mut files_correct = true;
+    for file in result.files {
+        if !files.contains(&file) {
+            files_correct = false;
+        }
+    }
+    assert!(files_correct);
+
+    let mut directories_correct = true;
+    for dir in result.directories {
+        if !directories.contains(&dir) {
+            directories_correct = false;
+        }
+    }
+    assert!(directories_correct);
+
+    // first level
+    options.depth = 1;
+    let result = get_dir_content2(&d_level_1, &options).unwrap();
+
+    assert_eq!(8, result.dir_size);
+    assert_eq!(1, result.files.len());
+    assert_eq!(2, result.directories.len());
+    files_correct = true;
+    for file in &result.files {
+        if !files.contains(&file) {
+            files_correct = false;
+        }
+    }
+    assert!(files_correct);
+    assert!(result.files.contains(&file1.to_str().unwrap().to_string()));
+
+    directories_correct = true;
+    for dir in &result.directories {
+        if !directories.contains(&dir) {
+            directories_correct = false;
+        }
+    }
+    assert!(directories_correct);
+    assert!(result.directories.contains(
+        &file1.parent().unwrap().to_str().unwrap().to_string(),
+    ));
+    assert!(result.directories.contains(
+        &file2.parent().unwrap().to_str().unwrap().to_string(),
+    ));
+
+    // fourth level
+    options.depth = 4;
+    let result = get_dir_content2(&d_level_1, &options).unwrap();
+
+    assert_eq!(32, result.dir_size);
+    assert_eq!(4, result.files.len());
+    assert_eq!(5, result.directories.len());
+    files_correct = true;
+    for file in &result.files {
+        if !files.contains(&file) {
+            files_correct = false;
+        }
+    }
+    assert!(files_correct);
+    assert!(result.files.contains(&file1.to_str().unwrap().to_string()));
+    assert!(result.files.contains(&file2.to_str().unwrap().to_string()));
+    assert!(result.files.contains(&file3.to_str().unwrap().to_string()));
+    assert!(result.files.contains(&file4.to_str().unwrap().to_string()));
+
+
+    directories_correct = true;
+    for dir in &result.directories {
+        if !directories.contains(&dir) {
+            directories_correct = false;
+        }
+    }
+    assert!(directories_correct);
+    assert!(result.directories.contains(
+        &file1.parent().unwrap().to_str().unwrap().to_string(),
+    ));
+    assert!(result.directories.contains(
+        &file2.parent().unwrap().to_str().unwrap().to_string(),
+    ));
+    assert!(result.directories.contains(
+        &file3.parent().unwrap().to_str().unwrap().to_string(),
+    ));
+    assert!(result.directories.contains(
+        &file4.parent().unwrap().to_str().unwrap().to_string(),
+    ));
+    assert!(result.directories.contains(
+        &file5.parent().unwrap().to_str().unwrap().to_string(),
+    ));
+}
+
+
 
 #[test]
 fn it_get_dir_content_path_file() {

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -11,8 +11,9 @@ const TEST_FOLDER: &'static str = "./tests/temp/file";
 
 
 fn files_eq<P, Q>(file1: P, file2: Q) -> Result<bool>
-    where P: AsRef<Path>,
-          Q: AsRef<Path>
+where
+    P: AsRef<Path>,
+    Q: AsRef<Path>,
 {
     let content1 = read_to_string(file1)?;
     let content2 = read_to_string(file2)?;
@@ -148,8 +149,8 @@ fn it_copy_not_file() {
         Err(err) => {
             match err.kind {
                 ErrorKind::InvalidFile => {
-                    let wrong_path = format!("Path \"{}\" is not a file!",
-                                             test_file.to_str().unwrap());
+                    let wrong_path =
+                        format!("Path \"{}\" is not a file!", test_file.to_str().unwrap());
                     assert_eq!(wrong_path, err.to_string());
                 }
                 _ => {
@@ -181,9 +182,11 @@ fn it_copy_source_not_exist() {
         Err(err) => {
             match err.kind {
                 ErrorKind::NotFound => {
-                    let wrong_path = format!("Path \"{}\" does not exist or you don't have \
+                    let wrong_path = format!(
+                        "Path \"{}\" does not exist or you don't have \
                                               access!",
-                                             test_file.to_str().unwrap());
+                        test_file.to_str().unwrap()
+                    );
                     assert_eq!(wrong_path, err.to_string());
                     ()
                 }
@@ -362,8 +365,8 @@ fn it_copy_progress_not_file() {
         Err(err) => {
             match err.kind {
                 ErrorKind::InvalidFile => {
-                    let wrong_path = format!("Path \"{}\" is not a file!",
-                                             test_file.to_str().unwrap());
+                    let wrong_path =
+                        format!("Path \"{}\" is not a file!", test_file.to_str().unwrap());
                     assert_eq!(wrong_path, err.to_string());
                 }
                 _ => {
@@ -447,9 +450,11 @@ fn it_copy_with_progress_source_not_exist() {
         Err(err) => {
             match err.kind {
                 ErrorKind::NotFound => {
-                    let wrong_path = format!("Path \"{}\" does not exist or you don't have \
+                    let wrong_path = format!(
+                        "Path \"{}\" does not exist or you don't have \
                                               access!",
-                                             test_file.to_str().unwrap());
+                        test_file.to_str().unwrap()
+                    );
 
                     assert_eq!(wrong_path, err.to_string());
                     ()
@@ -634,8 +639,8 @@ fn it_move_not_file() {
         Err(err) => {
             match err.kind {
                 ErrorKind::InvalidFile => {
-                    let wrong_path = format!("Path \"{}\" is not a file!",
-                                             test_file.to_str().unwrap());
+                    let wrong_path =
+                        format!("Path \"{}\" is not a file!", test_file.to_str().unwrap());
                     assert_eq!(wrong_path, err.to_string());
                 }
                 _ => {
@@ -669,9 +674,11 @@ fn it_move_source_not_exist() {
         Err(err) => {
             match err.kind {
                 ErrorKind::NotFound => {
-                    let wrong_path = format!("Path \"{}\" does not exist or you don't have \
+                    let wrong_path = format!(
+                        "Path \"{}\" does not exist or you don't have \
                                               access!",
-                                             test_file.to_str().unwrap());
+                        test_file.to_str().unwrap()
+                    );
 
                     assert_eq!(wrong_path, err.to_string());
                     ()
@@ -858,8 +865,8 @@ fn it_move_progress_not_file() {
         Err(err) => {
             match err.kind {
                 ErrorKind::InvalidFile => {
-                    let wrong_path = format!("Path \"{}\" is not a file!",
-                                             test_file.to_str().unwrap());
+                    let wrong_path =
+                        format!("Path \"{}\" is not a file!", test_file.to_str().unwrap());
                     assert_eq!(wrong_path, err.to_string());
                 }
                 _ => {
@@ -932,9 +939,11 @@ fn it_move_with_progress_source_not_exist() {
         Err(err) => {
             match err.kind {
                 ErrorKind::NotFound => {
-                    let wrong_path = format!("Path \"{}\" does not exist or you don't have \
+                    let wrong_path = format!(
+                        "Path \"{}\" does not exist or you don't have \
                                               access!",
-                                             test_file.to_str().unwrap());
+                        test_file.to_str().unwrap()
+                    );
 
                     assert_eq!(wrong_path, err.to_string());
                     ()

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -467,6 +467,333 @@ fn it_copy_exist_overwrite_and_skip_exist() {
 
 }
 
+#[test]
+fn it_copy_using_first_levels() {
+
+    let test_dir = Path::new(TEST_FOLDER).join("it_copy_using_first_levels");
+    let path_to = test_dir.join("out");
+    let d_level_1 = (test_dir.join("d_level_1"), path_to.join("d_level_1"));
+    let d_level_2 = (d_level_1.0.join("d_level_2"), d_level_1.1.join("d_level_2"));
+    let d_level_3 = (d_level_2.0.join("d_level_3"), d_level_2.1.join("d_level_3"));
+    let d_level_4 = (d_level_3.0.join("d_level_4"), d_level_3.1.join("d_level_4"));
+    let d_level_5 = (d_level_4.0.join("d_level_5"), d_level_4.1.join("d_level_5"));
+
+    let d2_level_1 = (test_dir.join("d2_level_1"), path_to.join("d2_level_1"));
+    let d2_level_2 = (d_level_1.0.join("d2_level_2"), d_level_1.1.join("d2_level_2"));
+    let d2_level_3 = (d_level_2.0.join("d2_level_3"), d_level_2.1.join("d2_level_3"));
+    let d2_level_4 = (d_level_3.0.join("d2_level_4"), d_level_3.1.join("d2_level_4"));
+    let d2_level_5 = (d_level_4.0.join("d2_level_5"), d_level_4.1.join("d2_level_5"));
+
+    let d3_level_1 = (test_dir.join("d3_level_1"), path_to.join("d3_level_1"));
+
+    let file1 = (d_level_1.0.join("file1.txt"),d_level_1.1.join("file1.txt"));
+    let file2 = (d_level_2.0.join("file2.txt"),d_level_2.1.join("file2.txt"));
+    let file3 = (d_level_3.0.join("file3.txt"),d_level_3.1.join("file3.txt"));
+    let file4 = (d_level_4.0.join("file4.txt"),d_level_4.1.join("file4.txt"));
+    let file5 = (d_level_5.0.join("file5.txt"),d_level_5.1.join("file5.txt"));
+
+    let file21 = (d2_level_1.0.join("file21.txt"),d2_level_1.1.join("file21.txt"));
+    let file22 = (d2_level_2.0.join("file22.txt"),d2_level_2.1.join("file22.txt"));
+    let file23 = (d2_level_3.0.join("file23.txt"),d2_level_3.1.join("file23.txt"));
+    let file24 = (d2_level_4.0.join("file24.txt"),d2_level_4.1.join("file24.txt"));
+    let file25 = (d2_level_5.0.join("file25.txt"),d2_level_5.1.join("file25.txt"));
+
+    let file31 = (d3_level_1.0.join("file31.txt"),d3_level_1.1.join("file31.txt"));
+
+    dir::create_all(&d_level_1.0, true).unwrap();
+    dir::create_all(&d_level_2.0, true).unwrap();
+    dir::create_all(&d_level_3.0, true).unwrap();
+    dir::create_all(&d_level_4.0, true).unwrap();
+    dir::create_all(&d_level_5.0, true).unwrap();
+    dir::create_all(&path_to, true).unwrap();
+
+    dir::create_all(&d2_level_1.0, true).unwrap();
+    dir::create_all(&d2_level_2.0, true).unwrap();
+    dir::create_all(&d2_level_3.0, true).unwrap();
+    dir::create_all(&d2_level_4.0, true).unwrap();
+    dir::create_all(&d2_level_5.0, true).unwrap();
+
+    dir::create_all(&d3_level_1.0, true).unwrap();
+
+    assert!(path_to.exists());
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+    assert!(d2_level_1.0.exists());
+    assert!(d2_level_2.0.exists());
+    assert!(d2_level_3.0.exists());
+    assert!(d2_level_4.0.exists());
+    assert!(d2_level_5.0.exists());
+
+    assert!(d3_level_1.0.exists());
+
+    assert!(!d_level_1.1.exists());
+    assert!(!d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    assert!(!d2_level_1.1.exists());
+    assert!(!d2_level_2.1.exists());
+    assert!(!d2_level_3.1.exists());
+    assert!(!d2_level_4.1.exists());
+    assert!(!d2_level_5.1.exists());
+
+    assert!(!d3_level_1.1.exists());
+
+    fs_extra::file::write_all(&file1.0, "content1").unwrap();
+    fs_extra::file::write_all(&file2.0, "content2").unwrap();
+    fs_extra::file::write_all(&file3.0, "content3").unwrap();
+    fs_extra::file::write_all(&file4.0, "content4").unwrap();
+    fs_extra::file::write_all(&file5.0, "content5").unwrap();
+
+    fs_extra::file::write_all(&file21.0, "2content1").unwrap();
+    fs_extra::file::write_all(&file22.0, "2content2").unwrap();
+    fs_extra::file::write_all(&file23.0, "2content3").unwrap();
+    fs_extra::file::write_all(&file24.0, "2content4").unwrap();
+    fs_extra::file::write_all(&file25.0, "2content5").unwrap();
+
+    fs_extra::file::write_all(&file31.0, "3content1").unwrap();
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(file21.0.exists());
+    assert!(file22.0.exists());
+    assert!(file23.0.exists());
+    assert!(file24.0.exists());
+    assert!(file25.0.exists());
+
+    assert!(file31.0.exists());
+
+    assert!(!file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    assert!(!file21.1.exists());
+    assert!(!file22.1.exists());
+    assert!(!file23.1.exists());
+    assert!(!file24.1.exists());
+    assert!(!file25.1.exists());
+
+    assert!(!file31.1.exists());
+
+
+    let mut from_paths = Vec::new();
+    from_paths.push(d_level_1.0.as_path());
+    from_paths.push(d2_level_1.0.as_path());
+    from_paths.push(d3_level_1.0.as_path());
+
+    let mut options = dir::CopyOptions::new();
+    options.depth = 1;
+    let result = copy_items(&from_paths, path_to, &options).unwrap();
+
+    assert_eq!(26, result);
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(file21.0.exists());
+    assert!(file22.0.exists());
+    assert!(file23.0.exists());
+    assert!(file24.0.exists());
+    assert!(file25.0.exists());
+
+    assert!(file31.0.exists());
+
+    assert!(file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    assert!(file21.1.exists());
+    assert!(!file22.1.exists());
+    assert!(!file23.1.exists());
+    assert!(!file24.1.exists());
+    assert!(!file25.1.exists());
+
+    assert!(file31.1.exists());
+    assert!(files_eq(&file1.0, &file1.1));
+    assert!(files_eq(&file21.0, &file21.1));
+    assert!(files_eq(&file31.0, &file31.1));
+}
+
+
+#[test]
+fn it_copy_using_four_levels() {
+
+    let test_dir = Path::new(TEST_FOLDER).join("it_copy_using_four_levels");
+    let path_to = test_dir.join("out");
+    let d_level_1 = (test_dir.join("d_level_1"), path_to.join("d_level_1"));
+    let d_level_2 = (d_level_1.0.join("d_level_2"), d_level_1.1.join("d_level_2"));
+    let d_level_3 = (d_level_2.0.join("d_level_3"), d_level_2.1.join("d_level_3"));
+    let d_level_4 = (d_level_3.0.join("d_level_4"), d_level_3.1.join("d_level_4"));
+    let d_level_5 = (d_level_4.0.join("d_level_5"), d_level_4.1.join("d_level_5"));
+
+    let d2_level_1 = (test_dir.join("d2_level_1"), path_to.join("d2_level_1"));
+    let d2_level_2 = (d_level_1.0.join("d2_level_2"), d_level_1.1.join("d2_level_2"));
+    let d2_level_3 = (d_level_2.0.join("d2_level_3"), d_level_2.1.join("d2_level_3"));
+    let d2_level_4 = (d_level_3.0.join("d2_level_4"), d_level_3.1.join("d2_level_4"));
+    let d2_level_5 = (d_level_4.0.join("d2_level_5"), d_level_4.1.join("d2_level_5"));
+
+    let d3_level_1 = (test_dir.join("d3_level_1"), path_to.join("d3_level_1"));
+
+    let file1 = (d_level_1.0.join("file1.txt"),d_level_1.1.join("file1.txt"));
+    let file2 = (d_level_2.0.join("file2.txt"),d_level_2.1.join("file2.txt"));
+    let file3 = (d_level_3.0.join("file3.txt"),d_level_3.1.join("file3.txt"));
+    let file4 = (d_level_4.0.join("file4.txt"),d_level_4.1.join("file4.txt"));
+    let file5 = (d_level_5.0.join("file5.txt"),d_level_5.1.join("file5.txt"));
+
+    let file21 = (d2_level_1.0.join("file21.txt"),d2_level_1.1.join("file21.txt"));
+    let file22 = (d2_level_2.0.join("file22.txt"),d2_level_2.1.join("file22.txt"));
+    let file23 = (d2_level_3.0.join("file23.txt"),d2_level_3.1.join("file23.txt"));
+    let file24 = (d2_level_4.0.join("file24.txt"),d2_level_4.1.join("file24.txt"));
+    let file25 = (d2_level_5.0.join("file25.txt"),d2_level_5.1.join("file25.txt"));
+
+    let file31 = (d3_level_1.0.join("file31.txt"),d3_level_1.1.join("file31.txt"));
+
+    dir::create_all(&d_level_1.0, true).unwrap();
+    dir::create_all(&d_level_2.0, true).unwrap();
+    dir::create_all(&d_level_3.0, true).unwrap();
+    dir::create_all(&d_level_4.0, true).unwrap();
+    dir::create_all(&d_level_5.0, true).unwrap();
+    dir::create_all(&path_to, true).unwrap();
+
+    dir::create_all(&d2_level_1.0, true).unwrap();
+    dir::create_all(&d2_level_2.0, true).unwrap();
+    dir::create_all(&d2_level_3.0, true).unwrap();
+    dir::create_all(&d2_level_4.0, true).unwrap();
+    dir::create_all(&d2_level_5.0, true).unwrap();
+
+    dir::create_all(&d3_level_1.0, true).unwrap();
+
+    assert!(path_to.exists());
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+    assert!(d2_level_1.0.exists());
+    assert!(d2_level_2.0.exists());
+    assert!(d2_level_3.0.exists());
+    assert!(d2_level_4.0.exists());
+    assert!(d2_level_5.0.exists());
+
+    assert!(d3_level_1.0.exists());
+
+    assert!(!d_level_1.1.exists());
+    assert!(!d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    assert!(!d2_level_1.1.exists());
+    assert!(!d2_level_2.1.exists());
+    assert!(!d2_level_3.1.exists());
+    assert!(!d2_level_4.1.exists());
+    assert!(!d2_level_5.1.exists());
+
+    assert!(!d3_level_1.1.exists());
+
+    fs_extra::file::write_all(&file1.0, "content1").unwrap();
+    fs_extra::file::write_all(&file2.0, "content2").unwrap();
+    fs_extra::file::write_all(&file3.0, "content3").unwrap();
+    fs_extra::file::write_all(&file4.0, "content4").unwrap();
+    fs_extra::file::write_all(&file5.0, "content5").unwrap();
+
+    fs_extra::file::write_all(&file21.0, "2content1").unwrap();
+    fs_extra::file::write_all(&file22.0, "2content2").unwrap();
+    fs_extra::file::write_all(&file23.0, "2content3").unwrap();
+    fs_extra::file::write_all(&file24.0, "2content4").unwrap();
+    fs_extra::file::write_all(&file25.0, "2content5").unwrap();
+
+    fs_extra::file::write_all(&file31.0, "3content1").unwrap();
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(file21.0.exists());
+    assert!(file22.0.exists());
+    assert!(file23.0.exists());
+    assert!(file24.0.exists());
+    assert!(file25.0.exists());
+
+    assert!(file31.0.exists());
+
+    assert!(!file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    assert!(!file21.1.exists());
+    assert!(!file22.1.exists());
+    assert!(!file23.1.exists());
+    assert!(!file24.1.exists());
+    assert!(!file25.1.exists());
+
+    assert!(!file31.1.exists());
+
+
+    let mut from_paths = Vec::new();
+    from_paths.push(d_level_1.0.as_path());
+    from_paths.push(d2_level_1.0.as_path());
+    from_paths.push(d3_level_1.0.as_path());
+
+    let mut options = dir::CopyOptions::new();
+    options.depth = 4;
+    let result = copy_items(&from_paths, path_to, &options).unwrap();
+
+    assert_eq!(77, result);
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(file21.0.exists());
+    assert!(file22.0.exists());
+    assert!(file23.0.exists());
+    assert!(file24.0.exists());
+    assert!(file25.0.exists());
+
+    assert!(file31.0.exists());
+
+    assert!(file1.1.exists());
+    assert!(file2.1.exists());
+    assert!(file3.1.exists());
+    assert!(file4.1.exists());
+    assert!(!file5.1.exists());
+
+    assert!(file21.1.exists());
+    assert!(file22.1.exists());
+    assert!(file23.1.exists());
+    assert!(file24.1.exists());
+    assert!(!file25.1.exists());
+
+    assert!(file31.1.exists());
+    assert!(files_eq(&file1.0, &file1.1));
+    assert!(files_eq(&file21.0, &file21.1));
+    assert!(files_eq(&file31.0, &file31.1));
+}
+
 
 #[test]
 fn it_copy_progress_work() {
@@ -1108,6 +1435,372 @@ fn it_copy_with_progress_exist_overwrite_and_skip_exist() {
 }
 
 
+#[test]
+fn it_copy_with_progress_using_first_levels() {
+
+    let test_dir = Path::new(TEST_FOLDER).join("it_copy_with_progress_using_first_levels");
+    let path_to = test_dir.join("out");
+    let d_level_1 = (test_dir.join("d_level_1"), path_to.join("d_level_1"));
+    let d_level_2 = (d_level_1.0.join("d_level_2"), d_level_1.1.join("d_level_2"));
+    let d_level_3 = (d_level_2.0.join("d_level_3"), d_level_2.1.join("d_level_3"));
+    let d_level_4 = (d_level_3.0.join("d_level_4"), d_level_3.1.join("d_level_4"));
+    let d_level_5 = (d_level_4.0.join("d_level_5"), d_level_4.1.join("d_level_5"));
+
+    let d2_level_1 = (test_dir.join("d2_level_1"), path_to.join("d2_level_1"));
+    let d2_level_2 = (d_level_1.0.join("d2_level_2"), d_level_1.1.join("d2_level_2"));
+    let d2_level_3 = (d_level_2.0.join("d2_level_3"), d_level_2.1.join("d2_level_3"));
+    let d2_level_4 = (d_level_3.0.join("d2_level_4"), d_level_3.1.join("d2_level_4"));
+    let d2_level_5 = (d_level_4.0.join("d2_level_5"), d_level_4.1.join("d2_level_5"));
+
+    let d3_level_1 = (test_dir.join("d3_level_1"), path_to.join("d3_level_1"));
+
+    let file1 = (d_level_1.0.join("file1.txt"),d_level_1.1.join("file1.txt"));
+    let file2 = (d_level_2.0.join("file2.txt"),d_level_2.1.join("file2.txt"));
+    let file3 = (d_level_3.0.join("file3.txt"),d_level_3.1.join("file3.txt"));
+    let file4 = (d_level_4.0.join("file4.txt"),d_level_4.1.join("file4.txt"));
+    let file5 = (d_level_5.0.join("file5.txt"),d_level_5.1.join("file5.txt"));
+
+    let file21 = (d2_level_1.0.join("file21.txt"),d2_level_1.1.join("file21.txt"));
+    let file22 = (d2_level_2.0.join("file22.txt"),d2_level_2.1.join("file22.txt"));
+    let file23 = (d2_level_3.0.join("file23.txt"),d2_level_3.1.join("file23.txt"));
+    let file24 = (d2_level_4.0.join("file24.txt"),d2_level_4.1.join("file24.txt"));
+    let file25 = (d2_level_5.0.join("file25.txt"),d2_level_5.1.join("file25.txt"));
+
+    let file31 = (d3_level_1.0.join("file31.txt"),d3_level_1.1.join("file31.txt"));
+
+    dir::create_all(&d_level_1.0, true).unwrap();
+    dir::create_all(&d_level_2.0, true).unwrap();
+    dir::create_all(&d_level_3.0, true).unwrap();
+    dir::create_all(&d_level_4.0, true).unwrap();
+    dir::create_all(&d_level_5.0, true).unwrap();
+    dir::create_all(&path_to, true).unwrap();
+
+    dir::create_all(&d2_level_1.0, true).unwrap();
+    dir::create_all(&d2_level_2.0, true).unwrap();
+    dir::create_all(&d2_level_3.0, true).unwrap();
+    dir::create_all(&d2_level_4.0, true).unwrap();
+    dir::create_all(&d2_level_5.0, true).unwrap();
+
+    dir::create_all(&d3_level_1.0, true).unwrap();
+
+    assert!(path_to.exists());
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+    assert!(d2_level_1.0.exists());
+    assert!(d2_level_2.0.exists());
+    assert!(d2_level_3.0.exists());
+    assert!(d2_level_4.0.exists());
+    assert!(d2_level_5.0.exists());
+
+    assert!(d3_level_1.0.exists());
+
+    assert!(!d_level_1.1.exists());
+    assert!(!d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    assert!(!d2_level_1.1.exists());
+    assert!(!d2_level_2.1.exists());
+    assert!(!d2_level_3.1.exists());
+    assert!(!d2_level_4.1.exists());
+    assert!(!d2_level_5.1.exists());
+
+    assert!(!d3_level_1.1.exists());
+
+    fs_extra::file::write_all(&file1.0, "content1").unwrap();
+    fs_extra::file::write_all(&file2.0, "content2").unwrap();
+    fs_extra::file::write_all(&file3.0, "content3").unwrap();
+    fs_extra::file::write_all(&file4.0, "content4").unwrap();
+    fs_extra::file::write_all(&file5.0, "content5").unwrap();
+
+    fs_extra::file::write_all(&file21.0, "2content1").unwrap();
+    fs_extra::file::write_all(&file22.0, "2content2").unwrap();
+    fs_extra::file::write_all(&file23.0, "2content3").unwrap();
+    fs_extra::file::write_all(&file24.0, "2content4").unwrap();
+    fs_extra::file::write_all(&file25.0, "2content5").unwrap();
+
+    fs_extra::file::write_all(&file31.0, "3content1").unwrap();
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(file21.0.exists());
+    assert!(file22.0.exists());
+    assert!(file23.0.exists());
+    assert!(file24.0.exists());
+    assert!(file25.0.exists());
+
+    assert!(file31.0.exists());
+
+    assert!(!file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    assert!(!file21.1.exists());
+    assert!(!file22.1.exists());
+    assert!(!file23.1.exists());
+    assert!(!file24.1.exists());
+    assert!(!file25.1.exists());
+
+    assert!(!file31.1.exists());
+
+
+    let mut options = dir::CopyOptions::new();
+    options.depth = 1;
+    let (tx, rx) = mpsc::channel();
+    let result = thread::spawn(move || {
+        let mut from_paths = Vec::new();
+        from_paths.push(d_level_1.0.as_path());
+        from_paths.push(d2_level_1.0.as_path());
+        from_paths.push(d3_level_1.0.as_path());
+
+        let func_test = |process_info: TransitProcess| {
+            tx.send(process_info).unwrap();
+            dir::TransitProcessResult::ContinueOrAbort
+        };
+
+        let result = copy_items_with_progress(&from_paths, &path_to, &options, func_test).unwrap();
+
+        assert_eq!(26, result);
+
+        assert!(file1.0.exists());
+        assert!(file2.0.exists());
+        assert!(file3.0.exists());
+        assert!(file4.0.exists());
+        assert!(file5.0.exists());
+
+        assert!(file21.0.exists());
+        assert!(file22.0.exists());
+        assert!(file23.0.exists());
+        assert!(file24.0.exists());
+        assert!(file25.0.exists());
+
+        assert!(file31.0.exists());
+
+        assert!(file1.1.exists());
+        assert!(!file2.1.exists());
+        assert!(!file3.1.exists());
+        assert!(!file4.1.exists());
+        assert!(!file5.1.exists());
+
+        assert!(file21.1.exists());
+        assert!(!file22.1.exists());
+        assert!(!file23.1.exists());
+        assert!(!file24.1.exists());
+        assert!(!file25.1.exists());
+
+        assert!(file31.1.exists());
+        assert!(files_eq(&file1.0, &file1.1));
+        assert!(files_eq(&file21.0, &file21.1));
+        assert!(files_eq(&file31.0, &file31.1));
+
+    }).join();
+
+    match result {
+        Ok(_) => {}
+        Err(err) => panic!(err),
+    }
+
+    match rx.recv() {
+        Err(_) => panic!("Errors should not be!"),
+        _ => {}
+
+    }
+}
+
+
+#[test]
+fn it_copy_with_progress_using_four_levels() {
+
+    let test_dir = Path::new(TEST_FOLDER).join("it_copy_with_progress_using_four_levels");
+    let path_to = test_dir.join("out");
+    let d_level_1 = (test_dir.join("d_level_1"), path_to.join("d_level_1"));
+    let d_level_2 = (d_level_1.0.join("d_level_2"), d_level_1.1.join("d_level_2"));
+    let d_level_3 = (d_level_2.0.join("d_level_3"), d_level_2.1.join("d_level_3"));
+    let d_level_4 = (d_level_3.0.join("d_level_4"), d_level_3.1.join("d_level_4"));
+    let d_level_5 = (d_level_4.0.join("d_level_5"), d_level_4.1.join("d_level_5"));
+
+    let d2_level_1 = (test_dir.join("d2_level_1"), path_to.join("d2_level_1"));
+    let d2_level_2 = (d_level_1.0.join("d2_level_2"), d_level_1.1.join("d2_level_2"));
+    let d2_level_3 = (d_level_2.0.join("d2_level_3"), d_level_2.1.join("d2_level_3"));
+    let d2_level_4 = (d_level_3.0.join("d2_level_4"), d_level_3.1.join("d2_level_4"));
+    let d2_level_5 = (d_level_4.0.join("d2_level_5"), d_level_4.1.join("d2_level_5"));
+
+    let d3_level_1 = (test_dir.join("d3_level_1"), path_to.join("d3_level_1"));
+
+    let file1 = (d_level_1.0.join("file1.txt"),d_level_1.1.join("file1.txt"));
+    let file2 = (d_level_2.0.join("file2.txt"),d_level_2.1.join("file2.txt"));
+    let file3 = (d_level_3.0.join("file3.txt"),d_level_3.1.join("file3.txt"));
+    let file4 = (d_level_4.0.join("file4.txt"),d_level_4.1.join("file4.txt"));
+    let file5 = (d_level_5.0.join("file5.txt"),d_level_5.1.join("file5.txt"));
+
+    let file21 = (d2_level_1.0.join("file21.txt"),d2_level_1.1.join("file21.txt"));
+    let file22 = (d2_level_2.0.join("file22.txt"),d2_level_2.1.join("file22.txt"));
+    let file23 = (d2_level_3.0.join("file23.txt"),d2_level_3.1.join("file23.txt"));
+    let file24 = (d2_level_4.0.join("file24.txt"),d2_level_4.1.join("file24.txt"));
+    let file25 = (d2_level_5.0.join("file25.txt"),d2_level_5.1.join("file25.txt"));
+
+    let file31 = (d3_level_1.0.join("file31.txt"),d3_level_1.1.join("file31.txt"));
+
+    dir::create_all(&d_level_1.0, true).unwrap();
+    dir::create_all(&d_level_2.0, true).unwrap();
+    dir::create_all(&d_level_3.0, true).unwrap();
+    dir::create_all(&d_level_4.0, true).unwrap();
+    dir::create_all(&d_level_5.0, true).unwrap();
+    dir::create_all(&path_to, true).unwrap();
+
+    dir::create_all(&d2_level_1.0, true).unwrap();
+    dir::create_all(&d2_level_2.0, true).unwrap();
+    dir::create_all(&d2_level_3.0, true).unwrap();
+    dir::create_all(&d2_level_4.0, true).unwrap();
+    dir::create_all(&d2_level_5.0, true).unwrap();
+
+    dir::create_all(&d3_level_1.0, true).unwrap();
+
+    assert!(path_to.exists());
+    assert!(d_level_1.0.exists());
+    assert!(d_level_2.0.exists());
+    assert!(d_level_3.0.exists());
+    assert!(d_level_4.0.exists());
+    assert!(d_level_5.0.exists());
+
+    assert!(d2_level_1.0.exists());
+    assert!(d2_level_2.0.exists());
+    assert!(d2_level_3.0.exists());
+    assert!(d2_level_4.0.exists());
+    assert!(d2_level_5.0.exists());
+
+    assert!(d3_level_1.0.exists());
+
+    assert!(!d_level_1.1.exists());
+    assert!(!d_level_2.1.exists());
+    assert!(!d_level_3.1.exists());
+    assert!(!d_level_4.1.exists());
+    assert!(!d_level_5.1.exists());
+
+    assert!(!d2_level_1.1.exists());
+    assert!(!d2_level_2.1.exists());
+    assert!(!d2_level_3.1.exists());
+    assert!(!d2_level_4.1.exists());
+    assert!(!d2_level_5.1.exists());
+
+    assert!(!d3_level_1.1.exists());
+
+    fs_extra::file::write_all(&file1.0, "content1").unwrap();
+    fs_extra::file::write_all(&file2.0, "content2").unwrap();
+    fs_extra::file::write_all(&file3.0, "content3").unwrap();
+    fs_extra::file::write_all(&file4.0, "content4").unwrap();
+    fs_extra::file::write_all(&file5.0, "content5").unwrap();
+
+    fs_extra::file::write_all(&file21.0, "2content1").unwrap();
+    fs_extra::file::write_all(&file22.0, "2content2").unwrap();
+    fs_extra::file::write_all(&file23.0, "2content3").unwrap();
+    fs_extra::file::write_all(&file24.0, "2content4").unwrap();
+    fs_extra::file::write_all(&file25.0, "2content5").unwrap();
+
+    fs_extra::file::write_all(&file31.0, "3content1").unwrap();
+
+    assert!(file1.0.exists());
+    assert!(file2.0.exists());
+    assert!(file3.0.exists());
+    assert!(file4.0.exists());
+    assert!(file5.0.exists());
+
+    assert!(file21.0.exists());
+    assert!(file22.0.exists());
+    assert!(file23.0.exists());
+    assert!(file24.0.exists());
+    assert!(file25.0.exists());
+
+    assert!(file31.0.exists());
+
+    assert!(!file1.1.exists());
+    assert!(!file2.1.exists());
+    assert!(!file3.1.exists());
+    assert!(!file4.1.exists());
+    assert!(!file5.1.exists());
+
+    assert!(!file21.1.exists());
+    assert!(!file22.1.exists());
+    assert!(!file23.1.exists());
+    assert!(!file24.1.exists());
+    assert!(!file25.1.exists());
+
+    assert!(!file31.1.exists());
+
+
+    let mut options = dir::CopyOptions::new();
+    options.depth = 4;
+    let (tx, rx) = mpsc::channel();
+    let result = thread::spawn(move || {
+        let mut from_paths = Vec::new();
+        from_paths.push(d_level_1.0.as_path());
+        from_paths.push(d2_level_1.0.as_path());
+        from_paths.push(d3_level_1.0.as_path());
+
+        let func_test = |process_info: TransitProcess| {
+            tx.send(process_info).unwrap();
+            dir::TransitProcessResult::ContinueOrAbort
+        };
+
+        let result = copy_items_with_progress(&from_paths, &path_to, &options, func_test).unwrap();
+
+        assert_eq!(77, result);
+
+        assert!(file1.0.exists());
+        assert!(file2.0.exists());
+        assert!(file3.0.exists());
+        assert!(file4.0.exists());
+        assert!(file5.0.exists());
+
+        assert!(file21.0.exists());
+        assert!(file22.0.exists());
+        assert!(file23.0.exists());
+        assert!(file24.0.exists());
+        assert!(file25.0.exists());
+
+        assert!(file31.0.exists());
+
+        assert!(file1.1.exists());
+        assert!(file2.1.exists());
+        assert!(file3.1.exists());
+        assert!(file4.1.exists());
+        assert!(!file5.1.exists());
+
+        assert!(file21.1.exists());
+        assert!(file22.1.exists());
+        assert!(file23.1.exists());
+        assert!(file24.1.exists());
+        assert!(!file25.1.exists());
+
+        assert!(file31.1.exists());
+        assert!(files_eq(&file1.0, &file1.1));
+        assert!(files_eq(&file21.0, &file21.1));
+        assert!(files_eq(&file31.0, &file31.1));
+
+    }).join();
+
+    match result {
+        Ok(_) => {}
+        Err(err) => panic!(err),
+    }
+
+    match rx.recv() {
+        Err(_) => panic!("Errors should not be!"),
+        _ => {}
+
+    }
+}
 
 
 


### PR DESCRIPTION
Release new functionals
- #5 Copy like `cp -r` in Unix. 
        For this functionality use `copy_inside` option of `CopyOptions`
- #7  Read directory by levels.
        For manage read levels use `depth` option of `DirOptions`
- #9 Copy by levels.
        This opportunity work only for copy operations. Use `depth` option of `CopyOptions`