### PR TITLE
Use Default trait for default values

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -47,8 +47,14 @@ impl CopyOptions {
     }
 }
 
+impl Default for CopyOptions {
+    fn default() -> Self {
+        CopyOptions::new()
+    }
+}
+
 ///	Options and flags which can be used to configure how read a directory.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct DirOptions {
     /// Sets levels reading. Set value 0 for read all directory folder. By default 0.
     pub depth: u64,
@@ -56,14 +62,8 @@ pub struct DirOptions {
 
 impl DirOptions {
     /// Initialize struct DirOptions with default value.
-    ///
-    /// ```rust,ignore
-    /// depth: 0
-    /// ```
     pub fn new() -> DirOptions {
-        DirOptions {
-            depth: 0, //  0 - all; 1 - only first level; 2 - second level; ... etc.
-        }
+        Default::default()
     }
 }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -33,6 +33,13 @@ impl CopyOptions {
         }
     }
 }
+
+impl Default for CopyOptions {
+    fn default() -> Self {
+        CopyOptions::new()
+    }
+}
+
 /// A structure  which include information about the current status of the copy or move file.
 pub struct TransitProcess {
     /// Copied bytes on this time.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,10 @@ pub mod error;
 ///     assert!(!test_file.1.exists());
 ///
 ///
-///     let mut options = CopyOptions::new();
-///     options.buffer_size = 1;
+///     let options = CopyOptions {
+///         buffer_size: 1,
+///         ..Default::default()
+///     }
 ///     let (tx, rx) = mpsc::channel();
 ///     thread::spawn(move || {
 ///         let handler = |process_info: TransitProcess| {
@@ -114,8 +116,10 @@ pub mod file;
 ///     assert!(file2.exists());
 ///
 ///
-///     let mut options = CopyOptions::new();
-///     options.buffer_size = 1;
+///     let options = CopyOptions {
+///         buffer_size: 1,
+///         ..Default::default(),
+///     };
 ///     let (tx, rx) = mpsc::channel();
 ///     thread::spawn(move || {
 ///         let handler = |process_info: TransitProcess| {
@@ -202,9 +206,11 @@ where
         } else {
             if let Some(file_name) = item.file_name() {
                 if let Some(file_name) = file_name.to_str() {
-                    let mut file_options = file::CopyOptions::new();
-                    file_options.overwrite = options.overwrite;
-                    file_options.skip_exist = options.skip_exist;
+                    let file_options = file::CopyOptions {
+                        overwrite: options.overwrite,
+                        skip_exist: options.skip_exist,
+                        ..Default::default()
+                    };
                     result += file::copy(item, to.as_ref().join(file_name), &file_options)?;
                 }
             } else {
@@ -346,10 +352,12 @@ where
             };
             result += dir::copy_with_progress(item, &to, &dir_options, handler)?;
         } else {
-            let mut file_options = file::CopyOptions::new();
-            file_options.overwrite = options.overwrite;
-            file_options.skip_exist = options.skip_exist;
-            file_options.buffer_size = options.buffer_size;
+            let mut file_options = file::CopyOptions {
+                overwrite: options.overwrite,
+                skip_exist: options.skip_exist,
+                buffer_size: options.buffer_size,
+                ..Default::default()
+            };
 
             if let Some(file_name) = item.file_name() {
                 if let Some(file_name) = file_name.to_str() {
@@ -532,10 +540,12 @@ where
 
             result += dir::move_dir(item, &to, options)?;
         } else {
-            let mut file_options = file::CopyOptions::new();
-            file_options.overwrite = options.overwrite;
-            file_options.skip_exist = options.skip_exist;
-            file_options.buffer_size = options.buffer_size;
+            let file_options = file::CopyOptions {
+                overwrite: options.overwrite,
+                skip_exist: options.skip_exist,
+                buffer_size: options.buffer_size,
+                ..Default::default()
+            };
 
             if let Some(file_name) = item.file_name() {
                 if let Some(file_name) = file_name.to_str() {
@@ -656,10 +666,12 @@ where
             };
             result += dir::move_dir_with_progress(item, &to, &dir_options, handler)?;
         } else {
-            let mut file_options = file::CopyOptions::new();
-            file_options.overwrite = options.overwrite;
-            file_options.skip_exist = options.skip_exist;
-            file_options.buffer_size = options.buffer_size;
+            let mut file_options = file::CopyOptions {
+                overwrite: options.overwrite,
+                skip_exist: options.skip_exist,
+                buffer_size: options.buffer_size,
+                ..Default::default()
+            };
 
             if let Some(file_name) = item.file_name() {
                 if let Some(file_name) = file_name.to_str() {


### PR DESCRIPTION
Using `Default` trait for default values is probably more idiomatic for Rust. In this case, it has a benefit that if a user doesn't need to change anything from the default value, they can simply do `Default::default()` rather than having to reference the `CopyOptions` types. 