### PR TITLE
Derive default for public types

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -19,8 +19,14 @@ pub struct CopyOptions {
     pub content_only: bool,
     /// Sets levels reading. Set 0 for read all directory folder. By default 0.
     ///
-    /// Warrning: Work only for copy operations!
+    /// Warning: Work only for copy operations!
     pub depth: u64,
+}
+
+impl Default for CopyOptions {
+    fn default() -> Self {
+        CopyOptions::new()
+    }
 }
 
 impl CopyOptions {
@@ -52,6 +58,12 @@ impl CopyOptions {
 pub struct DirOptions {
     /// Sets levels reading. Set value 0 for read all directory folder. By default 0.
     pub depth: u64,
+}
+
+impl Default for DirOptions {
+    fn default() -> Self {
+        DirOptions::new()
+    }
 }
 
 impl DirOptions {

--- a/src/file.rs
+++ b/src/file.rs
@@ -14,6 +14,12 @@ pub struct CopyOptions {
     pub buffer_size: usize,
 }
 
+impl Default for CopyOptions {
+    fn default() -> Self {
+        CopyOptions::new()
+    }
+}
+
 impl CopyOptions {
     /// Initialize struct CopyOptions with default value.
     ///


### PR DESCRIPTION
`Default` is the standard trait for making something new with defaults. While most folks prefer the `new` method, ensuring the public types derive `Default` lets them be used in a wider array of use cases.