### PR TITLE
Fix get size (and much more)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fs_extra"
 version = "1.2.0"
-description = "Expanding opportunities standard library std::fs and std::io. Recursively copy folders with recept information about process and much more." 
+description = "Expanding std::fs and std::io. Recursively copy folders with information about process and much more."
 license = "MIT"
 authors = ["Denis Kurilenko <webdesus@gmail.com>"]
 keywords = ["filesystem", "recursion", "copy", "dir", "file"]

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -4,20 +4,20 @@ use std::fs::{create_dir, create_dir_all, read_dir, remove_dir_all, Metadata};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-///	Options and flags which can be used to configure how a file will be  copied  or moved.
+///	Options and flags which can be used to configure how a file will be copied or moved.
 #[derive(Clone)]
 pub struct CopyOptions {
-    /// Sets the option true for overwrite existing files.
+    /// Overwrite existing files if true (default: false).
     pub overwrite: bool,
-    /// Sets the option true for skip existing files.
+    /// Skip existing files if true (default: false).
     pub skip_exist: bool,
-    /// Sets buffer size in bytes for copy/move work only with receipt information about process work.
+    /// Buffer size that specifies the amount of bytes to be moved or copied before the progress handler is called. This only affects functions with progress handlers. (default: 64000)
     pub buffer_size: usize,
-    /// Sets the option true for recursively copying a directory with a new name or place it inside the destination.(same behaviors like cp -r in Unix)
+    /// Recursively copy a directory with a new name or place it inside the destination (default: false, same behaviors as cp -r on Unix)
     pub copy_inside: bool,
-    /// Sets the option true, for copy only content without a created folder in the destination folder
+    /// Copy only contents without a creating a new folder in the destination folder (default: false).
     pub content_only: bool,
-    /// Sets levels reading. Set 0 for read all directory folder. By default 0.
+    /// Sets levels reading. Set 0 for read all directory folder (default: 0).
     ///
     /// Warning: Work only for copy operations!
     pub depth: u64,
@@ -31,7 +31,7 @@ impl CopyOptions {
     ///
     /// skip_exist: false
     ///
-    /// buffer_size: 64000 //64kb
+    /// buffer_size: 64000 // 64kb
     ///
     /// copy_inside: false
     /// ```
@@ -39,7 +39,7 @@ impl CopyOptions {
         CopyOptions {
             overwrite: false,
             skip_exist: false,
-            buffer_size: 64000, //64kb
+            buffer_size: 64000, // 64kb
             copy_inside: false,
             content_only: false,
             depth: 0,
@@ -53,7 +53,7 @@ impl Default for CopyOptions {
     }
 }
 
-///	Options and flags which can be used to configure how read a directory.
+///	Options and flags which can be used to configure how to read a directory.
 #[derive(Clone, Default)]
 pub struct DirOptions {
     /// Sets levels reading. Set value 0 for read all directory folder. By default 0.
@@ -100,7 +100,7 @@ pub enum TransitState {
     Normal,
     /// Pause state when destination path is exist.
     Exists,
-    /// Pause state when current process does not have the permission rights to access from or to
+    /// Pause state when current process does not have the permission to access from or to
     /// path.
     NoAccess,
 }
@@ -206,7 +206,7 @@ pub struct LsResult {
 ///
 /// * This `path` does not exist.
 /// * Invalid `path`.
-/// * The current process does not have the permission rights to access `path`.
+/// * The current process does not have the permission to access `path`.
 ///
 /// #Examples
 ///
@@ -370,13 +370,13 @@ where
     Ok(item)
 }
 
-/// Returned collection directory entries with information which you choose in config.
+/// Returns a collection of directory entries with attributes specifying the information that should be returned.
 ///
 /// This function takes to arguments:
 ///
 /// * `path` - Path to directory.
 ///
-/// * `config` - Set attributes which you want see inside return data.
+/// * `config` - Set attributes which you want see in return data.
 ///
 /// # Errors
 ///
@@ -385,7 +385,7 @@ where
 ///
 /// * This `path` directory does not exist.
 /// * Invalid `path`.
-/// * The current process does not have the permission rights to access `path`.
+/// * The current process does not have the permission to access `path`.
 ///
 /// #Examples
 ///
@@ -510,7 +510,7 @@ where
 /// * This `from` path is not a directory.
 /// * This `from` directory does not exist.
 /// * Invalid folder name for `from` or `to`.
-/// * The current process does not have the permission rights to access `from` or write `to`.
+/// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
 /// ```rust,ignore
@@ -621,7 +621,7 @@ where
 ///
 /// * This `path` directory does not exist.
 /// * Invalid `path`.
-/// * The current process does not have the permission rights to access `path`.
+/// * The current process does not have the permission to access `path`.
 ///
 /// # Examples
 /// ```rust,ignore
@@ -655,7 +655,7 @@ where
 ///
 /// * This `path` directory does not exist.
 /// * Invalid `path`.
-/// * The current process does not have the permission rights to access `path`.
+/// * The current process does not have the permission to access `path`.
 ///
 /// # Examples
 /// ```rust,ignore
@@ -739,7 +739,7 @@ where
 ///
 /// * This `path` directory does not exist.
 /// * Invalid `path`.
-/// * The current process does not have the permission rights to access `path`.
+/// * The current process does not have the permission to access `path`.
 ///
 /// # Examples
 /// ```rust,ignore
@@ -770,7 +770,7 @@ where
 }
 
 /// Copies the directory contents from one place to another using recursive method,
-/// with recept information about process. This function will also copy the
+/// with information about progress. This function will also copy the
 /// permission bits of the original files to destination files (not for directories).
 ///
 /// # Errors
@@ -781,7 +781,7 @@ where
 /// * This `from` path is not a directory.
 /// * This `from` directory does not exist.
 /// * Invalid folder name for `from` or `to`.
-/// * The current process does not have the permission rights to access `from` or write `to`.
+/// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
 /// ```rust,ignore
@@ -999,7 +999,7 @@ where
 /// * This `from` path is not a directory.
 /// * This `from` directory does not exist.
 /// * Invalid folder name for `from` or `to`.
-/// * The current process does not have the permission rights to access `from` or write `to`.
+/// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
 /// ```rust,ignore
@@ -1107,7 +1107,7 @@ where
     Ok(result)
 }
 
-/// Moves the directory contents from one place to another with recept information about process.
+/// Moves the directory contents from one place to another with information about progress.
 /// This function will also copy the permission bits of the original files to
 /// destination files (not for directories).
 ///
@@ -1119,7 +1119,7 @@ where
 /// * This `from` path is not a directory.
 /// * This `from` directory does not exist.
 /// * Invalid folder name for `from` or `to`.
-/// * The current process does not have the permission rights to access `from` or write `to`.
+/// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
 /// ```rust,ignore

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -4,7 +4,7 @@ use std::fs::{create_dir, create_dir_all, read_dir, remove_dir_all, Metadata};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
-///	Options and flags which can be used to configure how a file will be copied or moved.
+/// Options and flags which can be used to configure how a file will be copied or moved.
 #[derive(Clone)]
 pub struct CopyOptions {
     /// Overwrite existing files if true (default: false).
@@ -53,7 +53,7 @@ impl Default for CopyOptions {
     }
 }
 
-///	Options and flags which can be used to configure how to read a directory.
+// Options and flags which can be used to configure how to read a directory.
 #[derive(Clone, Default)]
 pub struct DirOptions {
     /// Sets levels reading. Set value 0 for read all directory folder. By default 0.
@@ -253,15 +253,13 @@ where
             } else {
                 item.insert(DirEntryAttr::Name, DirEntryValue::String(String::new()));
             }
+        } else if let Some(file_stem) = path.file_stem() {
+            item.insert(
+                DirEntryAttr::Name,
+                DirEntryValue::String(file_stem.to_os_string().into_string()?),
+            );
         } else {
-            if let Some(file_stem) = path.file_stem() {
-                item.insert(
-                    DirEntryAttr::Name,
-                    DirEntryValue::String(file_stem.to_os_string().into_string()?),
-                );
-            } else {
-                item.insert(DirEntryAttr::Name, DirEntryValue::String(String::new()));
-            }
+            item.insert(DirEntryAttr::Name, DirEntryValue::String(String::new()));
         }
     }
     if config.contains(&DirEntryAttr::Ext) {
@@ -423,10 +421,7 @@ where
     if config.contains(&DirEntryAttr::BaseInfo) {
         base = get_details_entry(&path, &config)?;
     }
-    Ok(LsResult {
-        items: items,
-        base: base,
-    })
+    Ok(LsResult { items, base })
 }
 
 /// Creates a new, empty directory at the provided path.
@@ -556,7 +551,7 @@ where
         err!("Invalid folder from", ErrorKind::InvalidFolder);
     }
     let mut to: PathBuf = to.as_ref().to_path_buf();
-    if !options.content_only && ((options.copy_inside && to.exists()) || !options.copy_inside) {
+    if (to.exists() || !options.copy_inside) && !options.content_only {
         to.push(dir_name);
     }
 
@@ -689,7 +684,7 @@ where
     let mut files = Vec::new();
     let mut dir_size;
     let item = path.as_ref().to_str();
-    if !item.is_some() {
+    if item.is_none() {
         err!("Invalid path", ErrorKind::InvalidPath);
     }
     let item = item.unwrap().to_string();
@@ -721,9 +716,9 @@ where
         files.push(item);
     }
     Ok(DirContent {
-        dir_size: dir_size,
-        files: files,
-        directories: directories,
+        dir_size,
+        files,
+        directories,
     })
 }
 
@@ -836,7 +831,7 @@ where
     } else {
         err!("Invalid folder from", ErrorKind::InvalidFolder);
     }
-    if !options.content_only && ((options.copy_inside && to.exists()) || !options.copy_inside) {
+    if (to.exists() || !options.copy_inside) && !options.content_only {
         to.push(dir_name);
     }
 
@@ -875,7 +870,7 @@ where
         let path = to.join(&tp);
 
         let file_name = path.file_name();
-        if !file_name.is_some() {
+        if file_name.is_none() {
             err!("No file name");
         }
         let file_name = file_name.unwrap();
@@ -1055,7 +1050,7 @@ where
         err!("Invalid folder from", ErrorKind::InvalidFolder);
     }
 
-    if !options.content_only && ((options.copy_inside && to.exists()) || !options.copy_inside) {
+    if (to.exists() || !options.copy_inside) && !options.content_only {
         to.push(dir_name);
     }
     let dir_content = get_dir_content(from)?;
@@ -1178,7 +1173,7 @@ where
     } else {
         err!("Invalid folder from", ErrorKind::InvalidFolder);
     }
-    if !options.content_only && ((options.copy_inside && to.exists()) || !options.copy_inside) {
+    if !(options.content_only || options.copy_inside && !to.exists()) {
         to.push(dir_name);
     }
 
@@ -1212,7 +1207,7 @@ where
         let path = to.join(&tp);
 
         let file_name = path.file_name();
-        if !file_name.is_some() {
+        if file_name.is_none() {
             err!("No file name");
         }
         let file_name = file_name.unwrap();

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -11,7 +11,7 @@ pub struct CopyOptions {
     pub overwrite: bool,
     /// Sets the option true for skip existing files.
     pub skip_exist: bool,
-    /// Sets buffer size for copy/move work only with receipt information about process work.
+    /// Sets buffer size in bytes for copy/move work only with receipt information about process work.
     pub buffer_size: usize,
     /// Sets the option true for recursively copying a directory with a new name or place it inside the destination.(same behaviors like cp -r in Unix)
     pub copy_inside: bool,
@@ -69,7 +69,7 @@ impl DirOptions {
 
 /// A structure which include information about directory
 pub struct DirContent {
-    /// Directory size.
+    /// Directory size in bytes.
     pub dir_size: u64,
     /// List all files directory and sub directories.
     pub files: Vec<String>,
@@ -610,9 +610,9 @@ where
 
 /// Return DirContent which contains information about directory:
 ///
-/// * Size directory.
-/// * List all files source directory(files subdirectories  included too).
-/// * List all directory and subdirectories source path.
+/// * Size of the directory in bytes.
+/// * List of source paths of files in the directory (files inside subdirectories included too).
+/// * List of source paths of all directories and subdirectories.
 ///
 /// # Errors
 ///

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -687,7 +687,7 @@ where
 {
     let mut directories = Vec::new();
     let mut files = Vec::new();
-    let mut dir_size = 0;
+    let mut dir_size;
     let item = path.as_ref().to_str();
     if !item.is_some() {
         err!("Invalid path", ErrorKind::InvalidPath);
@@ -695,6 +695,7 @@ where
     let item = item.unwrap().to_string();
 
     if path.as_ref().is_dir() {
+        dir_size = path.as_ref().metadata()?.len();
         directories.push(item);
         if depth == 0 || depth > 1 {
             if depth > 1 {

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -726,7 +726,10 @@ where
     })
 }
 
-/// Returns the size of the file or directory
+/// Returns the size of the file or directory in bytes
+///
+/// If used on a directory, this function will recursively iterate over every file and every
+/// directory inside the directory. This can be very time consuming if used on large directories.
 ///
 /// # Errors
 ///
@@ -754,9 +757,8 @@ where
     if path.as_ref().is_dir() {
         for entry in read_dir(&path)? {
             let _path = entry?.path();
-            if _path.is_file() {
-                result += _path.metadata()?.len();
-            } else {
+            result += _path.metadata()?.len();
+            if _path.is_dir() {
                 result += get_size(_path)?;
             }
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -104,7 +104,7 @@ impl Error {
     /// ```
     pub fn new(kind: ErrorKind, message: &str) -> Error {
         Error {
-            kind: kind,
+            kind,
             message: message.to_string(),
         }
     }

--- a/src/file.rs
+++ b/src/file.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 pub struct CopyOptions {
     /// Sets the option true for overwrite existing files.
     pub overwrite: bool,
-    /// Sets the option true for skipe existing files.
+    /// Sets the option true for skip existing files.
     pub skip_exist: bool,
     /// Sets buffer size for copy/move work only with receipt information about process work.
     pub buffer_size: usize,
@@ -40,7 +40,7 @@ impl Default for CopyOptions {
     }
 }
 
-/// A structure  which include information about the current status of the copy or move file.
+/// A structure which stores information about the current status of a file that's copied or moved. .
 pub struct TransitProcess {
     /// Copied bytes on this time.
     pub copied_bytes: u64,
@@ -58,7 +58,7 @@ pub struct TransitProcess {
 ///
 /// * This `from` path is not a file.
 /// * This `from` file does not exist.
-/// * The current process does not have the permission rights to access `from` or write `to`.
+/// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
 ///
@@ -109,7 +109,7 @@ where
     Ok(std::fs::copy(from, to)?)
 }
 
-/// Copies the contents of one file to another with recept information about process.
+/// Copies the contents of one file to another file with information about progress.
 /// This function will also copy the permission bits of the original file to the
 /// destination file.
 ///
@@ -120,7 +120,7 @@ where
 ///
 /// * This `from` path is not a file.
 /// * This `from` file does not exist.
-/// * The current process does not have the permission rights to access `from` or write `to`.
+/// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
 /// ```rust,ignore
@@ -200,7 +200,7 @@ where
     Ok(file_size)
 }
 
-/// Moves file from one place to another. This function will also copy the permission
+/// Moves a file from one place to another. This function will also copy the permission
 /// bits of the original file to the destination file.
 ///
 /// # Errors
@@ -210,7 +210,7 @@ where
 ///
 /// * This `from` path is not a file.
 /// * This `from` file does not exist.
-/// * The current process does not have the permission rights to access `from` or write `to`.
+/// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
 /// ```rust,ignore
@@ -238,7 +238,7 @@ where
     Ok(result)
 }
 
-/// Moves file from one place to another with recept information about process.
+/// Moves a file from one place to another with information about progress.
 /// This function will also copy the permission bits of the original file to the
 /// destination file.
 ///
@@ -249,7 +249,7 @@ where
 ///
 /// * This `from` path is not a file.
 /// * This `from` file does not exist.
-/// * The current process does not have the permission rights to access `from` or write `to`.
+/// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
 /// ```rust,ignore
@@ -293,7 +293,7 @@ where
 /// This function will return an error in the following situations, but is not limited to just
 /// these cases:
 ///
-/// * The current process does not have the permission rights to access `path`.
+/// * The current process does not have the permission to access `path`.
 ///
 /// # Example
 /// ```rust,ignore
@@ -314,7 +314,7 @@ where
     }
 }
 
-/// Read file content, placing him into `String`.
+/// Read file contents, placing them into `String`.
 ///
 /// # Errors
 ///
@@ -323,14 +323,14 @@ where
 ///
 /// * This `path` is not a file.
 /// * This `path` file does not exist.
-/// * The current process does not have the permission rights to access `path`.
+/// * The current process does not have the permission to access `path`.
 ///
 /// # Example
 /// ```rust,ignore
 /// extern crate fs_extra;
 /// use fs_extra::file::read_to_string;
 ///
-/// let file_content = read_to_string("foo.txt" )?; // Get file conent from foo.txt
+/// let file_content = read_to_string("foo.txt" )?; // Get file content from foo.txt
 /// println!("{}", file_content);
 ///
 /// ```
@@ -354,7 +354,7 @@ where
     Ok(result)
 }
 
-/// Write `String` content into inside target file.
+/// Write `String` content into file.
 ///
 /// # Errors
 ///
@@ -363,14 +363,14 @@ where
 ///
 /// * This `path` is not a file.
 /// * This `path` file does not exist.
-/// * The current process does not have the permission rights to access `path`.
+/// * The current process does not have the permission to access `path`.
 ///
 /// # Example
 /// ```rust,ignore
 /// extern crate fs_extra;
 /// use fs_extra::file::read_to_string;
 ///
-/// write_all("foo.txt", "conents" )?; // Create file foo.txt and send content inside
+/// write_all("foo.txt", "contents" )?; // Create file foo.txt and send content inside
 ///
 /// ```
 pub fn write_all<P>(path: P, content: &str) -> Result<()>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@ macro_rules! err {
     };
 }
 
-/// The error type for fs_extra operations with files and folder.
+/// The error type for fs_extra operations on files and directories.
 pub mod error;
-/// This module include extra methods for works with files.
+/// This module includes additional methods for working with files.
 ///
 /// One of the distinguishing features is receipt information
 /// about process work with files.
@@ -80,10 +80,10 @@ pub mod error;
 /// ```
 pub mod file;
 
-/// This module include extra methods for works with directories.
+/// This module includes additional methods for working with directories.
 ///
-/// One of the distinguishing features is receipt information
-/// about process work with directories and recursion operations.
+/// One of the additional features is information
+/// about process and recursion operations.
 ///
 /// # Example
 /// ```rust,ignore
@@ -156,8 +156,8 @@ pub mod dir;
 use error::*;
 use std::path::Path;
 
-/// Copies list directories and files to another place using recursive method. This function will
-/// also copy the permission bits of the original files to destionation files (not for
+/// Copies a list of directories and files to another place recursively. This function will
+/// also copy the permission bits of the original files to destination files (not for
 /// directories).
 ///
 /// # Errors
@@ -169,7 +169,7 @@ use std::path::Path;
 ///
 /// * List `from` contains  file or directory with invalid name.
 ///
-/// * The current process does not have the permission rights to access to file from `lists from` or
+/// * The current process does not have the permission to access to file from `lists from` or
 /// `to`.
 ///
 /// # Example
@@ -222,19 +222,19 @@ where
     Ok(result)
 }
 
-/// A structure which include information about the current status of the copy or move directory.
+/// A structure which includes information about the current status of copying or moving a directory.
 pub struct TransitProcess {
-    /// Copied bytes on this time for folder
+    /// Already copied bytes
     pub copied_bytes: u64,
-    /// All the bytes which should to copy or move (dir size).
+    /// All the bytes which should be copied or moved (dir size).
     pub total_bytes: u64,
     /// Copied bytes on this time for file.
     pub file_bytes_copied: u64,
-    /// Size current copied file.
+    /// Size of currently copied file.
     pub file_total_bytes: u64,
-    /// Name current copied file.
+    /// Name of currently copied file.
     pub file_name: String,
-    /// Name current copied folder.
+    /// Name of currently copied folder.
     pub dir_name: String,
     /// Transit state
     pub state: dir::TransitState,
@@ -254,9 +254,9 @@ impl Clone for TransitProcess {
     }
 }
 
-/// Copies list directories and files to another place using recursive method, with recept
-/// information about process. This function will also copy the permission bits of the
-/// original files to destionation files (not for directories).
+/// Copies a list of directories and files to another place recursively, with
+/// information about progress. This function will also copy the permission bits of the
+/// original files to destination files (not for directories).
 ///
 /// # Errors
 ///
@@ -267,7 +267,7 @@ impl Clone for TransitProcess {
 ///
 /// * List `from` contains  file or directory with invalid name.
 ///
-/// * The current process does not have the permission rights to access to file from `lists from` or
+/// * The current process does not have the permission to access to file from `lists from` or
 /// `to`.
 ///
 /// # Example
@@ -301,7 +301,7 @@ where
 {
     if options.content_only {
         err!(
-            "Options 'content_only' not acccess for copy_items_with_progress function",
+            "Options 'content_only' not access for copy_items_with_progress function",
             ErrorKind::Other
         );
     }
@@ -465,8 +465,8 @@ where
     Ok(result)
 }
 
-/// Moves list directories and files to another place using recursive method. This function will
-/// also copy the permission bits of the original files to destionation files (not for
+/// Moves a list of directories and files to another place recursively. This function will
+/// also copy the permission bits of the original files to destination files (not for
 /// directories).
 ///
 /// # Errors
@@ -478,7 +478,7 @@ where
 ///
 /// * List `from` contains  file or directory with invalid name.
 ///
-/// * The current process does not have the permission rights to access to file from `lists from` or
+/// * The current process does not have the permission to access to file from `lists from` or
 /// `to`.
 ///
 /// # Example
@@ -503,7 +503,7 @@ where
 {
     if options.content_only {
         err!(
-            "Options 'content_only' not acccess for move_items function",
+            "Options 'content_only' not access for move_items function",
             ErrorKind::Other
         );
     }
@@ -568,9 +568,9 @@ where
     Ok(result)
 }
 
-/// Moves list directories and files to another place using recursive method, with recept
-/// information about process. This function will also copy the permission bits of the
-/// original files to destionation files (not for directories).
+/// Moves a list of directories and files to another place recursively, with
+/// information about progress. This function will also copy the permission bits of the
+/// original files to destination files (not for directories).
 ///
 /// # Errors
 ///
@@ -581,7 +581,7 @@ where
 ///
 /// * List `from` contains  file or directory with invalid name.
 ///
-/// * The current process does not have the permission rights to access to file from `lists from` or
+/// * The current process does not have the permission to access to file from `lists from` or
 /// `to`.
 ///
 /// # Example
@@ -615,7 +615,7 @@ where
 {
     if options.content_only {
         err!(
-            "Options 'content_only' not acccess for move_items_with_progress function",
+            "Options 'content_only' not access for move_items_with_progress function",
             ErrorKind::Other
         );
     }
@@ -778,7 +778,7 @@ where
     Ok(result)
 }
 
-/// Removes list files or directories.
+/// Removes a list of files or directories.
 ///
 /// # Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,19 +203,17 @@ where
         let item = item.as_ref();
         if item.is_dir() {
             result += dir::copy(item, &to, options)?;
-        } else {
-            if let Some(file_name) = item.file_name() {
-                if let Some(file_name) = file_name.to_str() {
-                    let file_options = file::CopyOptions {
-                        overwrite: options.overwrite,
-                        skip_exist: options.skip_exist,
-                        ..Default::default()
-                    };
-                    result += file::copy(item, to.as_ref().join(file_name), &file_options)?;
-                }
-            } else {
-                err!("Invalid file name", ErrorKind::InvalidFileName);
+        } else if let Some(file_name) = item.file_name() {
+            if let Some(file_name) = file_name.to_str() {
+                let file_options = file::CopyOptions {
+                    overwrite: options.overwrite,
+                    skip_exist: options.skip_exist,
+                    ..Default::default()
+                };
+                result += file::copy(item, to.as_ref().join(file_name), &file_options)?;
             }
+        } else {
+            err!("Invalid file name", ErrorKind::InvalidFileName);
         }
     }
 
@@ -356,7 +354,6 @@ where
                 overwrite: options.overwrite,
                 skip_exist: options.skip_exist,
                 buffer_size: options.buffer_size,
-                ..Default::default()
             };
 
             if let Some(file_name) = item.file_name() {
@@ -544,7 +541,6 @@ where
                 overwrite: options.overwrite,
                 skip_exist: options.skip_exist,
                 buffer_size: options.buffer_size,
-                ..Default::default()
             };
 
             if let Some(file_name) = item.file_name() {
@@ -670,7 +666,6 @@ where
                 overwrite: options.overwrite,
                 skip_exist: options.skip_exist,
                 buffer_size: options.buffer_size,
-                ..Default::default()
             };
 
             if let Some(file_name) = item.file_name() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub mod error;
 ///
 /// fn main() {
 ///     example_copy();
-///
+/// }
 ///
 /// ```
 pub mod file;

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -828,10 +828,10 @@ fn it_copy_progress_work() {
             Ok(process_info) => {
                 if process_info.file_name == "test2.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(15, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 15, process_info.total_bytes);
                 } else if process_info.file_name == "test1.txt" {
                     assert_eq!(7, process_info.file_total_bytes);
-                    assert_eq!(15, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 15, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -957,14 +957,14 @@ fn it_copy_with_progress_work_dif_buf_size() {
             assert_eq!(i * 2, process_info.file_bytes_copied);
             assert_eq!(i * 2, process_info.copied_bytes);
             assert_eq!(8, process_info.file_total_bytes);
-            assert_eq!(16, process_info.total_bytes);
+            assert_eq!(get_dir_size() * 2 + 16, process_info.total_bytes);
         }
         for i in 1..5 {
             let process_info: TransitProcess = rx.recv().unwrap();
             assert_eq!(i * 2 + 8, process_info.copied_bytes);
             assert_eq!(i * 2, process_info.file_bytes_copied);
             assert_eq!(8, process_info.file_total_bytes);
-            assert_eq!(16, process_info.total_bytes);
+            assert_eq!(get_dir_size() * 2 + 16, process_info.total_bytes);
         }
 
         match result {
@@ -978,14 +978,14 @@ fn it_copy_with_progress_work_dif_buf_size() {
         assert_eq!(i, process_info.file_bytes_copied);
         assert_eq!(i, process_info.copied_bytes);
         assert_eq!(8, process_info.file_total_bytes);
-        assert_eq!(16, process_info.total_bytes);
+        assert_eq!(get_dir_size() * 2 + 16, process_info.total_bytes);
     }
     for i in 1..9 {
         let process_info: TransitProcess = rx.recv().unwrap();
         assert_eq!(i + 8, process_info.copied_bytes);
         assert_eq!(i, process_info.file_bytes_copied);
         assert_eq!(8, process_info.file_total_bytes);
-        assert_eq!(16, process_info.total_bytes);
+        assert_eq!(get_dir_size() * 2 + 16, process_info.total_bytes);
     }
 
     match result {
@@ -2322,10 +2322,10 @@ fn it_move_progress_work() {
             Ok(process_info) => {
                 if process_info.file_name == "test2.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(15, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 15, process_info.total_bytes);
                 } else if process_info.file_name == "test1.txt" {
                     assert_eq!(7, process_info.file_total_bytes);
-                    assert_eq!(15, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 15, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -2468,14 +2468,14 @@ fn it_move_with_progress_work_dif_buf_size() {
             assert_eq!(i * 2, process_info.file_bytes_copied);
             assert_eq!(i * 2, process_info.copied_bytes);
             assert_eq!(8, process_info.file_total_bytes);
-            assert_eq!(16, process_info.total_bytes);
+            assert_eq!(get_dir_size() * 2 + 16, process_info.total_bytes);
         }
         for i in 1..5 {
             let process_info: TransitProcess = rx.recv().unwrap();
             assert_eq!(i * 2 + 8, process_info.copied_bytes);
             assert_eq!(i * 2, process_info.file_bytes_copied);
             assert_eq!(8, process_info.file_total_bytes);
-            assert_eq!(16, process_info.total_bytes);
+            assert_eq!(get_dir_size() * 2 + 16, process_info.total_bytes);
         }
 
         match result {
@@ -2489,14 +2489,14 @@ fn it_move_with_progress_work_dif_buf_size() {
         assert_eq!(i, process_info.file_bytes_copied);
         assert_eq!(i, process_info.copied_bytes);
         assert_eq!(8, process_info.file_total_bytes);
-        assert_eq!(16, process_info.total_bytes);
+        assert_eq!(get_dir_size() * 2 + 16, process_info.total_bytes);
     }
     for i in 1..9 {
         let process_info: TransitProcess = rx.recv().unwrap();
         assert_eq!(i + 8, process_info.copied_bytes);
         assert_eq!(i, process_info.file_bytes_copied);
         assert_eq!(8, process_info.file_total_bytes);
-        assert_eq!(16, process_info.total_bytes);
+        assert_eq!(get_dir_size() * 2 + 16, process_info.total_bytes);
     }
 
     match result {
@@ -2877,7 +2877,7 @@ fn it_get_dir_content() {
 
     let result = get_dir_content(&path).unwrap();
 
-    assert_eq!(16, result.dir_size);
+    assert_eq!(get_dir_size() * 2 + 16, result.dir_size);
     assert_eq!(2, result.files.len());
     assert_eq!(2, result.directories.len());
 
@@ -2939,7 +2939,7 @@ fn it_get_dir_content_many_levels() {
     let mut options = DirOptions::new();
     let result = get_dir_content2(&d_level_1, &options).unwrap();
 
-    assert_eq!(40, result.dir_size);
+    assert_eq!(get_dir_size() * 5 + 40, result.dir_size);
     assert_eq!(5, result.files.len());
     assert_eq!(5, result.directories.len());
 
@@ -2977,7 +2977,7 @@ fn it_get_dir_content_many_levels() {
     options.depth = 1;
     let result = get_dir_content2(&d_level_1, &options).unwrap();
 
-    assert_eq!(8, result.dir_size);
+    assert_eq!(get_dir_size() * 2 + 8, result.dir_size);
     assert_eq!(1, result.files.len());
     assert_eq!(2, result.directories.len());
     files_correct = true;
@@ -3011,7 +3011,7 @@ fn it_get_dir_content_many_levels() {
     options.depth = 4;
     let result = get_dir_content2(&d_level_1, &options).unwrap();
 
-    assert_eq!(32, result.dir_size);
+    assert_eq!(get_dir_size() * 5 + 32, result.dir_size);
     assert_eq!(4, result.files.len());
     assert_eq!(5, result.directories.len());
     files_correct = true;
@@ -3749,10 +3749,10 @@ fn it_copy_with_progress_inside_work_target_dir_not_exist() {
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(15, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 15, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(7, process_info.file_total_bytes);
-                    assert_eq!(15, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 15, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -3829,10 +3829,10 @@ fn it_copy_with_progress_inside_work_target_dir_exist_with_no_source_dir_named_s
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -3917,10 +3917,10 @@ fn it_copy_with_progress_inside_no_overwrite_work_target_dir_exist_with_source_d
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -4004,10 +4004,10 @@ fn it_copy_with_progress_inside_overwrite_work_target_dir_exist_with_source_dir_
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -4386,10 +4386,10 @@ fn it_move_dir_with_progress_inside_work_target_dir_not_exist() {
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(15, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 15, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(7, process_info.file_total_bytes);
-                    assert_eq!(15, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 15, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -4472,10 +4472,10 @@ fn it_move_dir_with_progress_inside_work_target_dir_exist_with_no_source_dir_nam
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -4570,10 +4570,10 @@ fn it_move_dir_with_progress_inside_no_overwrite_work_target_dir_exist_with_sour
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }
@@ -4664,10 +4664,10 @@ fn it_move_dir_with_progress_inside_overwrite_work_target_dir_exist_with_source_
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(17, process_info.total_bytes);
+                    assert_eq!(get_dir_size() * 2 + 17, process_info.total_bytes);
                 } else {
                     panic!("Unknow file name!");
                 }

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -60,6 +60,14 @@ where
     true
 }
 
+// Returns the size of a directory. On Linux with ext4 this can be about 4kB.
+// Since the directory size can vary, we need to calculate is dynamically.
+fn get_dir_size() -> u64 {
+    std::fs::create_dir_all("./tests/temp").expect("Couldn't create test folder");
+
+    std::fs::metadata("./tests/temp").expect("Couldn't receive metadata of tests/temp folder").len()
+}
+
 const TEST_FOLDER: &'static str = "./tests/temp/dir";
 
 #[test]
@@ -2806,7 +2814,9 @@ fn it_get_folder_size() {
 
     let result = get_size(&path).unwrap();
 
-    assert_eq!(16, result);
+    let test_size: u64 = 16 + get_dir_size();
+
+    assert_eq!(test_size, result);
 }
 
 #[test]

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -65,7 +65,9 @@ where
 fn get_dir_size() -> u64 {
     std::fs::create_dir_all("./tests/temp").expect("Couldn't create test folder");
 
-    std::fs::metadata("./tests/temp").expect("Couldn't receive metadata of tests/temp folder").len()
+    std::fs::metadata("./tests/temp")
+        .expect("Couldn't receive metadata of tests/temp folder")
+        .len()
 }
 
 const TEST_FOLDER: &'static str = "./tests/temp/dir";
@@ -821,7 +823,8 @@ fn it_copy_progress_work() {
         assert_eq!(15, result);
         assert!(path_to.exists());
         assert!(compare_dir(&path_from, &path_to));
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -951,7 +954,8 @@ fn it_copy_with_progress_work_dif_buf_size() {
             assert_eq!(16, result);
             assert!(path_to.exists());
             assert!(compare_dir(&path_from, &path_to));
-        }).join();
+        })
+        .join();
         for i in 1..5 {
             let process_info: TransitProcess = rx.recv().unwrap();
             assert_eq!(i * 2, process_info.file_bytes_copied);
@@ -971,7 +975,8 @@ fn it_copy_with_progress_work_dif_buf_size() {
             Ok(_) => {}
             Err(err) => panic!(err),
         }
-    }).join();
+    })
+    .join();
 
     for i in 1..9 {
         let process_info: TransitProcess = rx.recv().unwrap();
@@ -1031,7 +1036,8 @@ fn it_copy_with_progress_source_not_exist() {
                 panic!("should be error");
             }
         }
-    }).join();
+    })
+    .join();
     match result {
         Ok(_) => {}
         Err(err) => panic!(err),
@@ -1090,7 +1096,8 @@ fn it_copy_with_progress_exist_overwrite() {
         assert_eq!(23, result);
         assert!(path_to.exists());
         assert!(compare_dir(&path_from, &path_to));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1199,7 +1206,8 @@ fn it_copy_with_progress_exist_skip_exist() {
         assert_eq!(0, result);
         assert!(path_to.exists());
         assert!(!compare_dir(&path_from, &path_to));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1260,7 +1268,8 @@ fn it_copy_with_progress_exist_overwrite_and_skip_exist() {
         assert_eq!(23, result);
         assert!(path_to.exists());
         assert!(compare_dir(&path_from, &path_to));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1360,7 +1369,8 @@ fn it_copy_with_progress_using_first_levels() {
         assert!(!file4.1.exists());
         assert!(!file5.1.exists());
         assert!(files_eq(&file1.0, &file1.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1467,7 +1477,8 @@ fn it_copy_with_progress_using_four_levels() {
         assert!(files_eq(&file2.0, &file2.1));
         assert!(files_eq(&file3.0, &file3.1));
         assert!(files_eq(&file4.0, &file4.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1547,7 +1558,8 @@ fn it_copy_with_progress_content_only_option() {
         assert!(files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file2.0, &file2.1));
         assert!(files_eq(&file3.0, &file3.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2315,7 +2327,8 @@ fn it_move_progress_work() {
         assert_eq!(15, result);
         assert!(path_to.exists());
         assert!(!path_from.exists());
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -2462,7 +2475,8 @@ fn it_move_with_progress_work_dif_buf_size() {
             assert_eq!(16, result);
             assert!(path_to.exists());
             assert!(!path_from.exists());
-        }).join();
+        })
+        .join();
         for i in 1..5 {
             let process_info: TransitProcess = rx.recv().unwrap();
             assert_eq!(i * 2, process_info.file_bytes_copied);
@@ -2482,7 +2496,8 @@ fn it_move_with_progress_work_dif_buf_size() {
             Ok(_) => {}
             Err(err) => panic!(err),
         }
-    }).join();
+    })
+    .join();
 
     for i in 1..9 {
         let process_info: TransitProcess = rx.recv().unwrap();
@@ -2542,7 +2557,8 @@ fn it_move_with_progress_source_not_exist() {
                 panic!("should be error");
             }
         }
-    }).join();
+    })
+    .join();
     match result {
         Ok(_) => {}
         Err(err) => panic!(err),
@@ -2601,7 +2617,8 @@ fn it_move_with_progress_exist_overwrite() {
         assert_eq!(23, result);
         assert!(path_to.exists());
         assert!(!path_from.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2658,7 +2675,8 @@ fn it_move_with_progress_exist_not_overwrite() {
                 _ => panic!("Wrong wrror"),
             },
         }
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2720,7 +2738,8 @@ fn it_move_with_progress_exist_skip_exist() {
         assert_eq!(0, result);
         assert!(path_from.exists());
         assert!(path_to.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2781,7 +2800,8 @@ fn it_move_with_progress_exist_overwrite_and_skip_exist() {
         assert_eq!(23, result);
         assert!(path_to.exists());
         assert!(!path_from.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2996,16 +3016,12 @@ fn it_get_dir_content_many_levels() {
         }
     }
     assert!(directories_correct);
-    assert!(
-        result
-            .directories
-            .contains(&file1.parent().unwrap().to_str().unwrap().to_string(),)
-    );
-    assert!(
-        result
-            .directories
-            .contains(&file2.parent().unwrap().to_str().unwrap().to_string(),)
-    );
+    assert!(result
+        .directories
+        .contains(&file1.parent().unwrap().to_str().unwrap().to_string(),));
+    assert!(result
+        .directories
+        .contains(&file2.parent().unwrap().to_str().unwrap().to_string(),));
 
     // fourth level
     options.depth = 4;
@@ -3033,31 +3049,21 @@ fn it_get_dir_content_many_levels() {
         }
     }
     assert!(directories_correct);
-    assert!(
-        result
-            .directories
-            .contains(&file1.parent().unwrap().to_str().unwrap().to_string(),)
-    );
-    assert!(
-        result
-            .directories
-            .contains(&file2.parent().unwrap().to_str().unwrap().to_string(),)
-    );
-    assert!(
-        result
-            .directories
-            .contains(&file3.parent().unwrap().to_str().unwrap().to_string(),)
-    );
-    assert!(
-        result
-            .directories
-            .contains(&file4.parent().unwrap().to_str().unwrap().to_string(),)
-    );
-    assert!(
-        result
-            .directories
-            .contains(&file5.parent().unwrap().to_str().unwrap().to_string(),)
-    );
+    assert!(result
+        .directories
+        .contains(&file1.parent().unwrap().to_str().unwrap().to_string(),));
+    assert!(result
+        .directories
+        .contains(&file2.parent().unwrap().to_str().unwrap().to_string(),));
+    assert!(result
+        .directories
+        .contains(&file3.parent().unwrap().to_str().unwrap().to_string(),));
+    assert!(result
+        .directories
+        .contains(&file4.parent().unwrap().to_str().unwrap().to_string(),));
+    assert!(result
+        .directories
+        .contains(&file5.parent().unwrap().to_str().unwrap().to_string(),));
 }
 
 #[test]
@@ -3440,7 +3446,8 @@ fn it_copy_with_progress_exist_user_decide_overwrite() {
         assert!(dir.0.exists());
         assert!(dir.1.exists());
         assert!(compare_dir(&dir.0, &out));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3503,7 +3510,8 @@ fn it_copy_with_progress_exist_user_decide_overwrite_all() {
         assert!(dir.0.exists());
         assert!(dir.1.exists());
         assert!(compare_dir(&dir.0, &out));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3565,7 +3573,8 @@ fn it_copy_with_progress_exist_user_decide_skip() {
         assert!(dir.0.exists());
         assert!(dir.1.exists());
         assert!(!compare_dir(&dir.0, &out));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3627,7 +3636,8 @@ fn it_copy_with_progress_exist_user_decide_skip_all() {
         assert!(dir.0.exists());
         assert!(dir.1.exists());
         assert!(!compare_dir(&dir.0, &out));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3693,7 +3703,8 @@ fn it_copy_with_progress_exist_user_decide_retry() {
         assert!(dir.0.exists());
         assert!(dir.1.exists());
         assert!(!compare_dir(&dir.0, &out));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3742,7 +3753,8 @@ fn it_copy_with_progress_inside_work_target_dir_not_exist() {
         assert!(root_dir1_sub.exists());
         assert!(root_dir2.exists());
         assert!(compare_dir_recursively(&root_dir1, &root_dir2));
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -3822,7 +3834,8 @@ fn it_copy_with_progress_inside_work_target_dir_exist_with_no_source_dir_named_s
         assert!(root_dir2_dir1.exists());
         assert!(root_dir2_dir3.exists());
         assert!(compare_dir(&root_dir1, &root_dir2));
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -3910,7 +3923,8 @@ fn it_copy_with_progress_inside_no_overwrite_work_target_dir_exist_with_source_d
         assert!(root_dir2_dir3.exists());
         assert!(!files_eq(file1, old_file1));
         assert!(!files_eq(file2, old_file2));
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -3997,7 +4011,8 @@ fn it_copy_with_progress_inside_overwrite_work_target_dir_exist_with_source_dir_
         assert!(root_dir2_dir1_sub.exists());
         assert!(root_dir2_dir3.exists());
         assert!(compare_dir(&root_dir1, &root_dir2));
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -4077,7 +4092,8 @@ fn it_move_with_progress_exist_user_decide_overwrite() {
         assert_eq!(16, result);
         assert!(!dir.0.exists());
         assert!(dir.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -4139,7 +4155,8 @@ fn it_move_with_progress_exist_user_decide_overwrite_all() {
         assert_eq!(16, result);
         assert!(!dir.0.exists());
         assert!(dir.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -4200,7 +4217,8 @@ fn it_move_with_progress_exist_user_decide_skip() {
         assert_eq!(0, result);
         assert!(dir.0.exists());
         assert!(dir.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -4261,7 +4279,8 @@ fn it_move_with_progress_exist_user_decide_skip_all() {
         assert_eq!(0, result);
         assert!(dir.0.exists());
         assert!(dir.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -4326,7 +4345,8 @@ fn it_move_with_progress_exist_user_decide_retry() {
         assert_eq!(0, result);
         assert!(dir.0.exists());
         assert!(dir.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -4379,7 +4399,8 @@ fn it_move_dir_with_progress_inside_work_target_dir_not_exist() {
         assert!(root_dir2_sub.exists());
         assert!(root_dir2_file1.exists());
         assert!(root_dir2_sub_file2.exists());
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -4465,7 +4486,8 @@ fn it_move_dir_with_progress_inside_work_target_dir_exist_with_no_source_dir_nam
         assert!(root_dir2_dir1_sub.exists());
         assert!(root_dir2_dir1_sub_file2.exists());
         assert!(root_dir2_dir3_file3.exists());
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -4563,7 +4585,8 @@ fn it_move_dir_with_progress_inside_no_overwrite_work_target_dir_exist_with_sour
         assert!(root_dir2_dir3_file3.exists());
         assert!(!files_eq(file1, old_file1));
         assert!(!files_eq(file2, old_file2));
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -4657,7 +4680,8 @@ fn it_move_dir_with_progress_inside_overwrite_work_target_dir_exist_with_source_
         assert!(root_dir2_dir1_file1.exists());
         assert!(root_dir2_dir1_sub_file2.exists());
         assert!(root_dir2_dir3_file3.exists());
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -4749,7 +4773,8 @@ fn it_move_with_progress_content_only_option() {
         assert!(file1.1.exists());
         assert!(file2.1.exists());
         assert!(file3.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -1,11 +1,11 @@
 // use std::io::{ErrorKind, Result};
 use std::path::{Path, PathBuf};
-use std::thread;
 use std::sync::mpsc;
+use std::thread;
 
 extern crate fs_extra;
-use fs_extra::file::*;
 use fs_extra::error::*;
+use fs_extra::file::*;
 
 const TEST_FOLDER: &'static str = "./tests/temp/file";
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -59,6 +59,14 @@ where
     true
 }
 
+// Returns the size of a directory. On Linux with ext4 this can be about 4kB.
+// Since the directory size can vary, we need to calculate is dynamically.
+fn get_dir_size() -> u64 {
+    std::fs::create_dir_all("./tests/temp").expect("Couldn't create test folder");
+
+    std::fs::metadata("./tests/temp").expect("Couldn't receive metadata of tests/temp folder").len()
+}
+
 const TEST_FOLDER: &'static str = "./tests/temp/lib";
 
 #[test]
@@ -911,10 +919,10 @@ fn it_copy_progress_work() {
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(41, process_info.total_bytes);
+                    assert_eq!(get_dir_size() + 41, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(41, process_info.total_bytes);
+                    assert_eq!(get_dir_size() + 41, process_info.total_bytes);
                 }
             }
             Err(TryRecvError::Disconnected) => {
@@ -1021,14 +1029,14 @@ fn it_copy_with_progress_work_dif_buf_size() {
             assert_eq!(i * 2, process_info.file_bytes_copied);
             assert_eq!(i * 2, process_info.copied_bytes);
             assert_eq!(8, process_info.file_total_bytes);
-            assert_eq!(40, process_info.total_bytes);
+            assert_eq!(get_dir_size() + 40, process_info.total_bytes);
         }
         for i in 1..5 {
             let process_info: TransitProcess = rx.recv().unwrap();
             assert_eq!(i * 2 + 8, process_info.copied_bytes);
             assert_eq!(i * 2, process_info.file_bytes_copied);
             assert_eq!(8, process_info.file_total_bytes);
-            assert_eq!(40, process_info.total_bytes);
+            assert_eq!(get_dir_size() + 40, process_info.total_bytes);
         }
 
         match result {
@@ -1042,14 +1050,14 @@ fn it_copy_with_progress_work_dif_buf_size() {
         assert_eq!(i, process_info.file_bytes_copied);
         assert_eq!(i, process_info.copied_bytes);
         assert_eq!(8, process_info.file_total_bytes);
-        assert_eq!(40, process_info.total_bytes);
+        assert_eq!(get_dir_size() + 40, process_info.total_bytes);
     }
     for i in 1..9 {
         let process_info: TransitProcess = rx.recv().unwrap();
         assert_eq!(i + 8, process_info.copied_bytes);
         assert_eq!(i, process_info.file_bytes_copied);
         assert_eq!(8, process_info.file_total_bytes);
-        assert_eq!(40, process_info.total_bytes);
+        assert_eq!(get_dir_size() + 40, process_info.total_bytes);
     }
 
     match result {
@@ -2366,10 +2374,10 @@ fn it_move_progress_work() {
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(41, process_info.total_bytes);
+                    assert_eq!(get_dir_size() + 41, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(41, process_info.total_bytes);
+                    assert_eq!(get_dir_size() + 41, process_info.total_bytes);
                 }
             }
             Err(TryRecvError::Disconnected) => {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -64,7 +64,9 @@ where
 fn get_dir_size() -> u64 {
     std::fs::create_dir_all("./tests/temp").expect("Couldn't create test folder");
 
-    std::fs::metadata("./tests/temp").expect("Couldn't receive metadata of tests/temp folder").len()
+    std::fs::metadata("./tests/temp")
+        .expect("Couldn't receive metadata of tests/temp folder")
+        .len()
 }
 
 const TEST_FOLDER: &'static str = "./tests/temp/lib";
@@ -912,7 +914,8 @@ fn it_copy_progress_work() {
         assert!(compare_dir(&dir2.0, &path_to));
         assert!(files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -1023,7 +1026,8 @@ fn it_copy_with_progress_work_dif_buf_size() {
             assert!(compare_dir(&dir2.0, &path_to));
             assert!(files_eq(&file1.0, &file1.1));
             assert!(files_eq(&file2.0, &file2.1));
-        }).join();
+        })
+        .join();
         for i in 1..5 {
             let process_info: TransitProcess = rx.recv().unwrap();
             assert_eq!(i * 2, process_info.file_bytes_copied);
@@ -1043,7 +1047,8 @@ fn it_copy_with_progress_work_dif_buf_size() {
             Ok(_) => {}
             Err(err) => panic!(err),
         }
-    }).join();
+    })
+    .join();
 
     for i in 1..9 {
         let process_info: TransitProcess = rx.recv().unwrap();
@@ -1183,7 +1188,8 @@ fn it_copy_with_progress_exist_overwrite() {
         assert!(compare_dir(&dir2.0, &path_to));
         assert!(files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1341,7 +1347,8 @@ fn it_copy_with_progress_exist_skip_exist() {
         assert!(compare_dir(&dir2.0, &path_to));
         assert!(!files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1429,7 +1436,8 @@ fn it_copy_with_progress_exist_overwrite_and_skip_exist() {
         assert!(compare_dir(&dir2.0, &path_to));
         assert!(files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1638,7 +1646,8 @@ fn it_copy_with_progress_using_first_levels() {
         assert!(files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file21.0, &file21.1));
         assert!(files_eq(&file31.0, &file31.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -1847,7 +1856,8 @@ fn it_copy_with_progress_using_four_levels() {
         assert!(files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file21.0, &file21.1));
         assert!(files_eq(&file31.0, &file31.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2367,7 +2377,8 @@ fn it_move_progress_work() {
         assert!(file3.1.exists());
         assert!(file4.1.exists());
         assert!(file5.1.exists());
-    }).join();
+    })
+    .join();
 
     loop {
         match rx.try_recv() {
@@ -2514,7 +2525,8 @@ fn it_move_with_progress_exist_overwrite() {
         assert!(file3.1.exists());
         assert!(file4.1.exists());
         assert!(file5.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2680,7 +2692,8 @@ fn it_move_with_progress_exist_skip_exist() {
         assert!(file4.1.exists());
         assert!(file5.1.exists());
         assert!(!files_eq(&file1.0, &file1.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2773,7 +2786,8 @@ fn it_move_with_progress_exist_overwrite_and_skip_exist() {
         assert!(file3.1.exists());
         assert!(file4.1.exists());
         assert!(file5.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -2947,7 +2961,8 @@ fn it_copy_with_progress_exist_user_decide_overwrite() {
         assert!(compare_dir(&dir2.0, &path_to));
         assert!(files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3050,7 +3065,8 @@ fn it_copy_with_progress_exist_user_decide_overwrite_all() {
         assert!(compare_dir(&dir2.0, &path_to));
         assert!(files_eq(&file1.0, &file1.1));
         assert!(files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3152,7 +3168,8 @@ fn it_copy_with_progress_exist_user_decide_skip() {
         assert!(!compare_dir(&dir2.0, &path_to));
         assert!(!files_eq(&file1.0, &file1.1));
         assert!(!files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3254,7 +3271,8 @@ fn it_copy_with_progress_exist_user_decide_skip_all() {
         assert!(!compare_dir(&dir2.0, &path_to));
         assert!(!files_eq(&file1.0, &file1.1));
         assert!(!files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3361,7 +3379,8 @@ fn it_copy_with_progress_exist_user_decide_retry() {
         assert!(!compare_dir(&dir2.0, &path_to));
         assert!(!files_eq(&file1.0, &file1.1));
         assert!(!files_eq(&file2.0, &file2.1));
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3459,7 +3478,8 @@ fn it_move_with_progress_exist_user_decide_overwrite() {
         assert!(!dir2.0.exists());
         assert!(dir1.1.exists());
         assert!(dir2.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3558,7 +3578,8 @@ fn it_move_with_progress_exist_user_decide_overwrite_all() {
         assert!(!dir2.0.exists());
         assert!(dir1.1.exists());
         assert!(dir2.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3656,7 +3677,8 @@ fn it_move_with_progress_exist_user_decide_skip() {
         assert!(dir2.0.exists());
         assert!(dir1.1.exists());
         assert!(dir2.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3756,7 +3778,8 @@ fn it_move_with_progress_exist_user_decide_skip_all() {
         assert!(dir2.1.exists());
         assert!(file1.0.exists());
         assert!(file2.0.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}
@@ -3859,7 +3882,8 @@ fn it_move_with_progress_exist_user_decide_retry() {
         assert!(dir2.0.exists());
         assert!(dir1.1.exists());
         assert!(dir2.1.exists());
-    }).join();
+    })
+    .join();
 
     match result {
         Ok(_) => {}


### PR DESCRIPTION
This PR fixes the get_size and the get_dir_content (and related) functions. Also, the tests are modified to work with the updated functions.

Additionally I included some further commits:
- Improved documentation (two commits)
- Improved code formatting (using cargo fmt)
- Applied clippy lints

In general the documentation was in a pretty bad shape and it still is to some degree because I couldn't fix everything. **Also I think this crate needs better maintenance it has 112,532 downloads per month!!!!** A popular crate like this should also upgrade to edition="2018"! If you don't have time for this at least look for a new maintainer :)