### PR TITLE
Remove trailing semicolon from err! macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 macro_rules! err {
     ($text:expr, $kind:expr) => {
-        return Err(Error::new($kind, $text));
+        return Err(Error::new($kind, $text))
     };
 
     ($text:expr) => {


### PR DESCRIPTION
If the `semicolon_in_expressions_from_macros` lint is ever turned into a
hard error, your crate will stop compiling. This commit ensures that
your crate will compile on both current and future versions of Rust.

See https://github.com/rust-lang/rust/issues/79813 for more details