### PR TITLE
Fix grammar error in error message

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -98,7 +98,7 @@ pub struct TransitProcess {
 pub enum TransitState {
     /// Standard state.
     Normal,
-    /// Pause state when destination path is exist.
+    /// Pause state when destination path exists.
     Exists,
     /// Pause state when current process does not have the permission to access from or to
     /// path.

--- a/src/file.rs
+++ b/src/file.rs
@@ -101,7 +101,7 @@ where
         }
 
         if let Some(msg) = to.as_ref().to_str() {
-            let msg = format!("Path \"{}\" is exist", msg);
+            let msg = format!("Path \"{}\" exists", msg);
             err!(&msg, ErrorKind::AlreadyExists);
         }
     }
@@ -171,7 +171,7 @@ where
         }
 
         if let Some(msg) = to.as_ref().to_str() {
-            let msg = format!("Path \"{}\" is exist", msg);
+            let msg = format!("Path \"{}\" exists", msg);
             err!(&msg, ErrorKind::AlreadyExists);
         }
     }

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -422,7 +422,7 @@ fn it_copy_exist_not_overwrite() {
     match copy(&path_from, &path_to, &options) {
         Err(err) => match err.kind {
             ErrorKind::AlreadyExists => {
-                let wrong_path = format!("Path \"{}\" is exist", exist_path.to_str().unwrap());
+                let wrong_path = format!("Path \"{}\" exists", exist_path.to_str().unwrap());
                 assert_eq!(wrong_path, err.to_string());
             }
             _ => {
@@ -1949,7 +1949,7 @@ fn it_move_exist_not_overwrite() {
     match move_dir(&path_from, &path_to, &options) {
         Err(err) => match err.kind {
             ErrorKind::AlreadyExists => {
-                let wrong_path = format!("Path \"{}\" is exist", exist_path.to_str().unwrap());
+                let wrong_path = format!("Path \"{}\" exists", exist_path.to_str().unwrap());
                 assert_eq!(wrong_path, err.to_string());
             }
             _ => {

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -228,7 +228,7 @@ fn it_copy_exist_not_overwrite() {
     match copy(&test_file, &test_file_out, &options) {
         Ok(_) => panic!("should be error"),
         Err(err) => {
-            let file_path = format!("Path \"{}\" is exist", test_file_out.to_str().unwrap());
+            let file_path = format!("Path \"{}\" exists", test_file_out.to_str().unwrap());
             assert_eq!(file_path, err.to_string());
             assert!(!files_eq(test_file, test_file_out).unwrap());
             ()
@@ -497,7 +497,7 @@ fn it_copy_with_progress_exist_not_overwrite() {
     match copy_with_progress(&test_file, &test_file_out, &options, func_test) {
         Ok(_) => panic!("should be error"),
         Err(err) => {
-            let file_path = format!("Path \"{}\" is exist", test_file_out.to_str().unwrap());
+            let file_path = format!("Path \"{}\" exists", test_file_out.to_str().unwrap());
 
             assert_eq!(file_path, err.to_string());
             assert!(!files_eq(test_file, test_file_out).unwrap());
@@ -704,7 +704,7 @@ fn it_move_exist_not_overwrite() {
     match move_file(&test_file, &test_file_out, &options) {
         Ok(_) => panic!("should be error"),
         Err(err) => {
-            let file_path = format!("Path \"{}\" is exist", test_file_out.to_str().unwrap());
+            let file_path = format!("Path \"{}\" exists", test_file_out.to_str().unwrap());
 
             assert_eq!(file_path, err.to_string());
             assert!(!files_eq(test_file, test_file_out).unwrap());
@@ -964,7 +964,7 @@ fn it_move_with_progress_exist_not_overwrite() {
     match move_file_with_progress(&test_file, &test_file_out, &options, func_test) {
         Ok(_) => panic!("should be error"),
         Err(err) => {
-            let file_path = format!("Path \"{}\" is exist", test_file_out.to_str().unwrap());
+            let file_path = format!("Path \"{}\" exists", test_file_out.to_str().unwrap());
 
             assert_eq!(file_path, err.to_string());
             assert!(!files_eq(test_file, test_file_out).unwrap());


### PR DESCRIPTION
Using your library, I found a little grammar error in one of the error messages. I fixed it from "is exist" to "exists". Useful in particular when the error message is visible to the user, e.g. in command line programs.