### PR TITLE
Fix `dir::get_size`'s handling of symlinks

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -786,8 +786,6 @@ pub fn get_size<P>(path: P) -> Result<u64>
 where
     P: AsRef<Path>,
 {
-    let mut size_in_bytes = 0;
-
     // Using `fs::symlink_metadata` since we don't want to follow symlinks,
     // as we're calculating the exact size of the requested path itself.
     let path_metadata = path.as_ref().symlink_metadata()?;
@@ -795,7 +793,7 @@ where
     // For directories this is just the size of the directory entry itself, not its contents.
     // Similarly for symlinks, this is the size of the symlink entry, not its target.
     // In both cases, we still want to count these so that we get an accurate total size.
-    size_in_bytes += path_metadata.len();
+    let mut size_in_bytes = path_metadata.len();
 
     if path_metadata.is_dir() {
         for entry in read_dir(&path)? {

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -269,6 +269,7 @@ where
     let metadata = path.metadata()?;
     get_details_entry_with_meta(path, config, metadata)
 }
+
 fn get_details_entry_with_meta<P>(
     path: P,
     config: &HashSet<DirEntryAttr>,
@@ -758,7 +759,7 @@ where
     })
 }
 
-/// Returns the size of the file or directory in bytes.
+/// Returns the size of the file or directory in bytes.(!important: folders size not count)
 ///
 /// If used on a directory, this function will recursively iterate over every file and every
 /// directory inside the directory. This can be very time consuming if used on large directories.
@@ -790,10 +791,7 @@ where
     // as we're calculating the exact size of the requested path itself.
     let path_metadata = path.as_ref().symlink_metadata()?;
 
-    // For directories this is just the size of the directory entry itself, not its contents.
-    // Similarly for symlinks, this is the size of the symlink entry, not its target.
-    // In both cases, we still want to count these so that we get an accurate total size.
-    let mut size_in_bytes = path_metadata.len();
+    let mut size_in_bytes = 0;
 
     if path_metadata.is_dir() {
         for entry in read_dir(&path)? {
@@ -810,6 +808,8 @@ where
                 size_in_bytes += entry_metadata.len();
             }
         }
+    } else {
+        size_in_bytes = path_metadata.len();
     }
 
     Ok(size_in_bytes)

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -2862,15 +2862,8 @@ fn it_get_folder_size() {
     // Total size comprises of:
     // - 100 bytes for the standard file "test1.txt"
     // - 300 bytes for the standard file "test2.txt"
-    // - 2 x directories (one for the top level directory "dir", another for the subdirectory "sub"),
-    //   whose size varies by filesystem, so is dynamically calculated. We cannot use `get_dir_size()`
-    //   since even the directory metadata size varies from directory to directory, so we instead have
-    //   to retrieve the size of both "dir" and "sub" directly.
     // - (On supported platforms) 1 x symlink whose whose size varies by filesystem, so is dynamically calculated.
-    let mut expected_size = 100
-        + 300
-        + fs::symlink_metadata(&path).unwrap().len()
-        + fs::symlink_metadata(&sub_dir_path).unwrap().len();
+    let mut expected_size = 100 + 300;
 
     if symlink_file.exists() {
         // `fs::symlink_metadata` does not follow symlinks, so this is the size of the symlink itself, not its target.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -59,16 +59,6 @@ where
     true
 }
 
-// Returns the size of a directory. On Linux with ext4 this can be about 4kB.
-// Since the directory size can vary, we need to calculate is dynamically.
-fn get_dir_size() -> u64 {
-    std::fs::create_dir_all("./tests/temp").expect("Couldn't create test folder");
-
-    std::fs::metadata("./tests/temp")
-        .expect("Couldn't receive metadata of tests/temp folder")
-        .len()
-}
-
 const TEST_FOLDER: &'static str = "./tests/temp/lib";
 
 #[test]
@@ -922,10 +912,10 @@ fn it_copy_progress_work() {
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(get_dir_size() + 41, process_info.total_bytes);
+                    assert_eq!(41, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(get_dir_size() + 41, process_info.total_bytes);
+                    assert_eq!(41, process_info.total_bytes);
                 }
             }
             Err(TryRecvError::Disconnected) => {
@@ -1033,14 +1023,14 @@ fn it_copy_with_progress_work_dif_buf_size() {
             assert_eq!(i * 2, process_info.file_bytes_copied);
             assert_eq!(i * 2, process_info.copied_bytes);
             assert_eq!(8, process_info.file_total_bytes);
-            assert_eq!(get_dir_size() + 40, process_info.total_bytes);
+            assert_eq!(40, process_info.total_bytes);
         }
         for i in 1..5 {
             let process_info: TransitProcess = rx.recv().unwrap();
             assert_eq!(i * 2 + 8, process_info.copied_bytes);
             assert_eq!(i * 2, process_info.file_bytes_copied);
             assert_eq!(8, process_info.file_total_bytes);
-            assert_eq!(get_dir_size() + 40, process_info.total_bytes);
+            assert_eq!(40, process_info.total_bytes);
         }
 
         match result {
@@ -1055,14 +1045,14 @@ fn it_copy_with_progress_work_dif_buf_size() {
         assert_eq!(i, process_info.file_bytes_copied);
         assert_eq!(i, process_info.copied_bytes);
         assert_eq!(8, process_info.file_total_bytes);
-        assert_eq!(get_dir_size() + 40, process_info.total_bytes);
+        assert_eq!(40, process_info.total_bytes);
     }
     for i in 1..9 {
         let process_info: TransitProcess = rx.recv().unwrap();
         assert_eq!(i + 8, process_info.copied_bytes);
         assert_eq!(i, process_info.file_bytes_copied);
         assert_eq!(8, process_info.file_total_bytes);
-        assert_eq!(get_dir_size() + 40, process_info.total_bytes);
+        assert_eq!(40, process_info.total_bytes);
     }
 
     match result {
@@ -2385,10 +2375,10 @@ fn it_move_progress_work() {
             Ok(process_info) => {
                 if process_info.file_name == "file2.txt" {
                     assert_eq!(9, process_info.file_total_bytes);
-                    assert_eq!(get_dir_size() + 41, process_info.total_bytes);
+                    assert_eq!(41, process_info.total_bytes);
                 } else if process_info.file_name == "file1.txt" {
                     assert_eq!(8, process_info.file_total_bytes);
-                    assert_eq!(get_dir_size() + 41, process_info.total_bytes);
+                    assert_eq!(41, process_info.total_bytes);
                 }
             }
             Err(TryRecvError::Disconnected) => {


### PR DESCRIPTION
~This makes `dir::get_size` give a correct calculation of the size of a path of directory, that now matches that returned by eg: `du --bytes -s <path>`.~ (Due to changes requested during review, this is no longer the case.)

Before:
- Symlinks were followed, causing double-counting of symlinked files (see #59).
- Whilst the metadata size of subdirectory entries was counted correctly, the metadata size of the parent directory (the initial `path` passed into `dir::get_size`) was not counted. See:
   https://github.com/webdesus/fs_extra/issues/25#issuecomment-1172428052

Now:
- Symlinks are no longer followed (fixing the regression from #34), so that only the size of the symlink itself is included (as expected), and not the size of the symlink's target.
- ~If the initial `path` passed into `dir::get_size` is a directory, the size of that directory entry itself is now correctly counted (like it was already being counted for subdirectories).~ Due to changes requested during review, this is no longer the case. The metadata size of the directory entries (entries only, not the contents) is now excluded entirely from the total size.

In addition, the size calculations are performed using `DirEntry::metadata`, rather than unnecessarily converting to a path and then passing that path to `fs::{metadata,symlink_metadata}`.

Fixes #25.
Fixes #59.