### PR TITLE
Fix some code blocks attributes

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -246,7 +246,7 @@ pub struct LsResult {
 ///
 /// #Examples
 ///
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::{get_details_entry, DirEntryAttr};
 /// use std::collections::{HashMap, HashSet};
@@ -423,7 +423,7 @@ where
 ///
 /// #Examples
 ///
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::{ls, DirEntryAttr, LsResult};
 /// use std::collections::HashSet;
@@ -479,7 +479,7 @@ where
 ///
 /// #Examples
 ///
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::create;
 ///
@@ -514,11 +514,12 @@ where
 ///
 /// #Examples
 ///
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::create_all;
 ///
 /// create_all("/some/dir", false); // create directory some and dir
+/// ```
 pub fn create_all<P>(path: P, erase: bool) -> Result<()>
 where
     P: AsRef<Path>,
@@ -544,7 +545,7 @@ where
 /// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::copy;
 ///
@@ -554,7 +555,6 @@ where
 ///
 /// // copy source/dir1 to target/dir1
 /// copy("source/dir1", "target/dir1", &options)?;
-///
 /// ```
 pub fn copy<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
 where
@@ -655,7 +655,7 @@ where
 /// * The current process does not have the permission to access `path`.
 ///
 /// # Examples
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::get_dir_content;
 ///
@@ -664,7 +664,6 @@ where
 ///     println!("{}", directory); // print directory path
 /// }
 /// ```
-///
 pub fn get_dir_content<P>(path: P) -> Result<DirContent>
 where
     P: AsRef<Path>,
@@ -689,7 +688,7 @@ where
 /// * The current process does not have the permission to access `path`.
 ///
 /// # Examples
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::{DirOptions, get_dir_content2};
 ///
@@ -700,7 +699,6 @@ where
 ///     println!("{}", directory); // print directory path
 /// }
 /// ```
-///
 pub fn get_dir_content2<P>(path: P, options: &DirOptions) -> Result<DirContent>
 where
     P: AsRef<Path>,
@@ -773,7 +771,7 @@ where
 /// * The current process does not have the permission to access `path`.
 ///
 /// # Examples
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::get_size;
 ///
@@ -815,7 +813,7 @@ where
 /// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::copy;
 ///
@@ -826,7 +824,6 @@ where
 /// }
 /// // copy source/dir1 to target/dir1
 /// copy_with_progress("source/dir1", "target/dir1", &options, handle)?;
-///
 /// ```
 pub fn copy_with_progress<P, Q, F>(
     from: P,
@@ -1033,7 +1030,7 @@ where
 /// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::move_dir;
 ///
@@ -1041,7 +1038,6 @@ where
 ///
 /// // move source/dir1 to target/dir1
 /// move_dir("source/dir1", "target/dir1", &options)?;
-///
 /// ```
 pub fn move_dir<P, Q>(from: P, to: Q, options: &CopyOptions) -> Result<u64>
 where
@@ -1153,7 +1149,7 @@ where
 /// * The current process does not have the permission to access `from` or write `to`.
 ///
 /// # Example
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::move_dir_with_progress;
 ///
@@ -1165,7 +1161,6 @@ where
 ///
 /// // move source/dir1 to target/dir1
 /// move_dir_with_progress("source/dir1", "target/dir1", &options, handle)?;
-///
 /// ```
 pub fn move_dir_with_progress<P, Q, F>(
     from: P,
@@ -1368,7 +1363,7 @@ where
 /// Removes directory.
 ///
 /// # Example
-/// ```rust,ignore
+/// ```no_run
 /// extern crate fs_extra;
 /// use fs_extra::dir::remove;
 ///


### PR DESCRIPTION
I think it's still important that code blocks are ensured to be compiling, which can be done using `no_run`.