### PR TITLE
Fix symlink bugs

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -619,6 +619,7 @@ where
             overwrite: options.overwrite,
             skip_exist: options.skip_exist,
             buffer_size: options.buffer_size,
+            follow: false,
         };
         let mut result_copy: Result<u64>;
         let mut work = true;
@@ -931,6 +932,7 @@ where
             overwrite: options.overwrite,
             skip_exist: options.skip_exist,
             buffer_size: options.buffer_size,
+            follow: false,
         };
 
         if let Some(file_name) = file_name.to_str() {
@@ -1126,6 +1128,7 @@ where
             overwrite: options.overwrite,
             skip_exist: options.skip_exist,
             buffer_size: options.buffer_size,
+            follow: false,
         };
 
         let mut result_copy: Result<u64>;
@@ -1268,6 +1271,7 @@ where
             overwrite: options.overwrite,
             skip_exist: options.skip_exist,
             buffer_size: options.buffer_size,
+            follow: false,
         };
 
         if let Some(file_name) = file_name.to_str() {

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -943,7 +943,7 @@ where
         }
 
         info_process.file_bytes_copied = 0;
-        info_process.file_total_bytes = Path::new(&file).metadata()?.len();
+        info_process.file_total_bytes = Path::new(&file).symlink_metadata()?.len();
 
         let mut result_copy: Result<u64>;
         let mut work = true;
@@ -1283,7 +1283,7 @@ where
         }
 
         info_process.file_bytes_copied = 0;
-        info_process.file_total_bytes = Path::new(&file).metadata()?.len();
+        info_process.file_total_bytes = Path::new(&file).symlink_metadata()?.len();
 
         let mut result_copy: Result<u64>;
         let mut work = true;

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1149,6 +1149,7 @@ where
             }
         }
     }
+
     if is_remove {
         remove(from)?;
     }

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -727,7 +727,8 @@ where
     }
     let item = item.unwrap().to_string();
 
-    if path.as_ref().is_dir() {
+    let meta = path.as_ref().symlink_metadata()?;
+    if meta.is_dir() {
         dir_size = path.as_ref().metadata()?.len();
         directories.push(item);
         if depth == 0 || depth > 1 {
@@ -750,7 +751,7 @@ where
             }
         }
     } else {
-        dir_size = path.as_ref().symlink_metadata()?.len();
+        dir_size = meta.len();
         files.push(item);
     }
     Ok(DirContent {

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -750,7 +750,7 @@ where
             }
         }
     } else {
-        dir_size = path.as_ref().metadata()?.len();
+        dir_size = path.as_ref().symlink_metadata()?.len();
         files.push(item);
     }
     Ok(DirContent {

--- a/src/file.rs
+++ b/src/file.rs
@@ -2,8 +2,10 @@ use crate::error::{Error, ErrorKind, Result};
 use std;
 use std::fs::{read_link, remove_file, File};
 use std::io::{Read, Write};
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "redox"))]
 use std::os::unix::fs::symlink;
+#[cfg(target_os = "wasi")]
+use std::os::wasi::fs::symlink_path as symlink;
 use std::path::Path;
 
 // Options and flags which can be used to configure how a file will be  copied  or moved.
@@ -113,7 +115,7 @@ where
     }
 
     if !options.follow && from.is_symlink() {
-        #[cfg(unix)]
+        #[cfg(any(unix, target_os = "wasi", target_os = "redox"))]
         symlink(read_link(from)?, &to)?;
         return Ok(to.as_os_str().len() as u64);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,6 +354,7 @@ where
                 overwrite: options.overwrite,
                 skip_exist: options.skip_exist,
                 buffer_size: options.buffer_size,
+                follow: false,
             };
 
             if let Some(file_name) = item.file_name() {
@@ -541,6 +542,7 @@ where
                 overwrite: options.overwrite,
                 skip_exist: options.skip_exist,
                 buffer_size: options.buffer_size,
+                follow: false,
             };
 
             if let Some(file_name) = item.file_name() {
@@ -666,6 +668,7 @@ where
                 overwrite: options.overwrite,
                 skip_exist: options.skip_exist,
                 buffer_size: options.buffer_size,
+                follow: false,
             };
 
             if let Some(file_name) = item.file_name() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
+
 macro_rules! err {
     ($text:expr, $kind:expr) => {
         return Err(Error::new($kind, $text))

--- a/tests/dir.rs
+++ b/tests/dir.rs
@@ -4860,11 +4860,57 @@ fn it_move_with_symlinks() {
     fs_extra::file::write_all(&path_from.join(&test_file), "test").unwrap();
 
     create_file_symlink(&test_file, &path_from.join(&test_link)).unwrap();
-    create_file_symlink(&Path::new("..").join(test_file), &path_from.join(&test_link1)).unwrap();
+    create_file_symlink(
+        &Path::new("..").join(test_file),
+        &path_from.join(&test_link1),
+    )
+    .unwrap();
 
     copy(&path_from, &path_to1.join("dir"), &copy_options).unwrap();
     assert!(compare_dir(&path_from, &path_to1));
 
     move_dir(&path_to1.join("dir"), &path_to2.join("dir"), &copy_options).unwrap();
+    assert!(compare_dir(&path_from, &path_to2));
+}
+
+#[test]
+fn it_move_with_symlinks_progress() {
+    let copy_options = &CopyOptions {
+        copy_inside: true,
+        ..CopyOptions::new()
+    };
+    let test_dir = Path::new(TEST_FOLDER).join("it_move_with_symlinks_progress");
+    let path_from = test_dir.clone().join("dir");
+    let path_to1 = test_dir.clone().join("dir_cpy1");
+    let path_to2 = test_dir.clone().join("dir_cpy2");
+
+    let test_file = Path::new("file");
+    let test_link = Path::new("link");
+    let test_dir1 = Path::new("dir_in");
+    let test_link1 = test_dir1.clone().join("link1");
+
+    let func_test = |_process_info: TransitProcess| TransitProcessResult::ContinueOrAbort;
+
+    let _ = remove(test_dir);
+    create_all(&path_from.join(&test_dir1), true).unwrap();
+    fs_extra::file::write_all(&path_from.join(&test_file), "test").unwrap();
+
+    create_file_symlink(&test_file, &path_from.join(&test_link)).unwrap();
+    create_file_symlink(
+        &Path::new("..").join(test_file),
+        &path_from.join(&test_link1),
+    )
+    .unwrap();
+
+    copy_with_progress(&path_from, &path_to1.join("dir"), &copy_options, &func_test).unwrap();
+    assert!(compare_dir(&path_from, &path_to1));
+
+    move_dir_with_progress(
+        &path_to1.join("dir"),
+        &path_to2.join("dir"),
+        &copy_options,
+        &func_test,
+    )
+    .unwrap();
     assert!(compare_dir(&path_from, &path_to2));
 }

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -168,8 +168,7 @@ fn it_copy_source_not_exist() {
         Err(err) => match err.kind {
             ErrorKind::NotFound => {
                 let wrong_path = format!(
-                    "Path \"{}\" does not exist or you don't have \
-                     access!",
+                    "Path \"{}\" is a broken symlink or doesn't exist!",
                     test_file.to_str().unwrap()
                 );
                 assert_eq!(wrong_path, err.to_string());
@@ -643,8 +642,7 @@ fn it_move_source_not_exist() {
         Err(err) => match err.kind {
             ErrorKind::NotFound => {
                 let wrong_path = format!(
-                    "Path \"{}\" does not exist or you don't have \
-                     access!",
+                    "Path \"{}\" is a broken symlink or doesn't exist!",
                     test_file.to_str().unwrap()
                 );
 

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -183,10 +183,7 @@ fn it_copy_source_not_exist() {
         Ok(_) => panic!("should be error"),
         Err(err) => match err.kind {
             ErrorKind::NotFound => {
-                let wrong_path = format!(
-                    "Path \"{}\" is a broken symlink or doesn't exist!",
-                    test_file.to_str().unwrap()
-                );
+                let wrong_path = format!("Path \"{}\" doesn't exist!", test_file.to_str().unwrap());
                 assert_eq!(wrong_path, err.to_string());
                 ()
             }
@@ -657,10 +654,7 @@ fn it_move_source_not_exist() {
         Ok(_) => panic!("should be error"),
         Err(err) => match err.kind {
             ErrorKind::NotFound => {
-                let wrong_path = format!(
-                    "Path \"{}\" is a broken symlink or doesn't exist!",
-                    test_file.to_str().unwrap()
-                );
+                let wrong_path = format!("Path \"{}\" doesn't exist!", test_file.to_str().unwrap());
 
                 assert_eq!(wrong_path, err.to_string());
                 ()

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -1036,7 +1036,7 @@ fn it_move_with_progress_exist_overwrite_and_skip_exist() {
 }
 
 #[test]
-#[cfg(unix)]
+#[cfg(any(unix, windows, target_os = "redox", target_os = "wasi"))]
 fn it_copy_not_overwrite_broken_symlink() {
     let mut test_file = PathBuf::from(TEST_FOLDER);
     test_file.push("it_copy_not_overwrite_broken_symlink");
@@ -1065,6 +1065,7 @@ fn it_copy_not_overwrite_broken_symlink() {
 }
 
 #[test]
+#[cfg(any(unix, windows, target_os = "redox", target_os = "wasi"))]
 fn it_copy_symlink_not_follow() {
     let mut test_file = PathBuf::from(TEST_FOLDER);
     test_file.push("it_copy_symlink_not_follow");

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -442,8 +442,7 @@ fn it_copy_with_progress_source_not_exist() {
         Err(err) => match err.kind {
             ErrorKind::NotFound => {
                 let wrong_path = format!(
-                    "Path \"{}\" does not exist or you don't have \
-                     access!",
+                    "Path \"{}\" doesn't exist!",
                     test_file.to_str().unwrap()
                 );
 
@@ -905,8 +904,7 @@ fn it_move_with_progress_source_not_exist() {
         Err(err) => match err.kind {
             ErrorKind::NotFound => {
                 let wrong_path = format!(
-                    "Path \"{}\" does not exist or you don't have \
-                     access!",
+                    "Path \"{}\" doesn't exist!",
                     test_file.to_str().unwrap()
                 );
 

--- a/tests/file.rs
+++ b/tests/file.rs
@@ -441,10 +441,7 @@ fn it_copy_with_progress_source_not_exist() {
         Ok(_) => panic!("should be error"),
         Err(err) => match err.kind {
             ErrorKind::NotFound => {
-                let wrong_path = format!(
-                    "Path \"{}\" doesn't exist!",
-                    test_file.to_str().unwrap()
-                );
+                let wrong_path = format!("Path \"{}\" doesn't exist!", test_file.to_str().unwrap());
 
                 assert_eq!(wrong_path, err.to_string());
                 ()
@@ -903,10 +900,7 @@ fn it_move_with_progress_source_not_exist() {
         Ok(_) => panic!("should be error"),
         Err(err) => match err.kind {
             ErrorKind::NotFound => {
-                let wrong_path = format!(
-                    "Path \"{}\" doesn't exist!",
-                    test_file.to_str().unwrap()
-                );
+                let wrong_path = format!("Path \"{}\" doesn't exist!", test_file.to_str().unwrap());
 
                 assert_eq!(wrong_path, err.to_string());
                 ()


### PR DESCRIPTION
# The problem

When user attempts to move a directory that contains symbolic links, it might result in an error without a proper cleanup.

## How to reproduce

Sample code that produces the issue:

```rust
use fs_extra::dir::{CopyOptions, move_dir};

fn main() {
    println!("{:?}", move_dir("dir", "dir1", &CopyOptions {
        copy_inside: true,
        ..CopyOptions::new()}));

    println!("Hello, world!");
}
```

Sample input:

```bash
$ tree dir
dir
├── dir1
│   └── link1 -> ../file
├── file
└── link -> file
```

## What happens

Running the above program against the given input leaves `dir` and `dir1` directories in the following state:

```bash
$ tree dir1 dir
dir1
├── dir1
│   └── link1
└── file
dir
├── dir1
└── link -> file
```

What happens here is the `file` is copied before the `link` and the [exists](https://github.com/webdesus/fs_extra/blob/1754296075e7cc4a25feaa876a3f4b9daccc0b98/src/file.rs#L97) function returns false because it follows symbolic links ([docs reference](https://doc.rust-lang.org/stable/std/path/struct.Path.html#method.exists)). After that, the function fails without cleaning up half-moved directory. Also, `link1` after the copy holds the same data as `file` (which it points to) instead of being a symbolic link. I think this is not an expected behavior as well.

# My fix

I fixed it by adding a `follow` field to `file::CopyOptions` (which defaults to `true`) and set it to `false` when invoked from move and copy functions from `dir` module. Setting this field prevents following symbolic links when moving or copying. Additionally, I fixed another small bug - setting `overwrite` to `false` in `file::CopyOptions` would still overwrite dangling symlinks, now checks are performed to prevent this.

My solution breaks backward compatibility, if you don't want to introduce such changes to your repository now, let me know and I can try to adjust it to be backwards compatible.
